### PR TITLE
Change accessibility of arc/segment/point constructor to public

### DIFF
--- a/src/Hilke.KineticConvolution/Arc.cs
+++ b/src/Hilke.KineticConvolution/Arc.cs
@@ -6,7 +6,7 @@ namespace Hilke.KineticConvolution
 {
     public sealed class Arc<TAlgebraicNumber> : Tracing<TAlgebraicNumber>
     {
-        internal Arc(
+        public Arc(
             IAlgebraicNumberCalculator<TAlgebraicNumber> calculator,
             Fraction weight,
             Point<TAlgebraicNumber> center,

--- a/src/Hilke.KineticConvolution/Point.cs
+++ b/src/Hilke.KineticConvolution/Point.cs
@@ -6,7 +6,7 @@ namespace Hilke.KineticConvolution
     {
         private readonly IAlgebraicNumberCalculator<TAlgebraicNumber> _calculator;
 
-        internal Point(IAlgebraicNumberCalculator<TAlgebraicNumber> calculator, TAlgebraicNumber x, TAlgebraicNumber y)
+        public Point(IAlgebraicNumberCalculator<TAlgebraicNumber> calculator, TAlgebraicNumber x, TAlgebraicNumber y)
         {
             _calculator = calculator ?? throw new ArgumentNullException(nameof(calculator));
             X = x ?? throw new ArgumentNullException(nameof(x));

--- a/src/Hilke.KineticConvolution/Segment.cs
+++ b/src/Hilke.KineticConvolution/Segment.cs
@@ -6,7 +6,7 @@ namespace Hilke.KineticConvolution
 {
     public sealed class Segment<TAlgebraicNumber> : Tracing<TAlgebraicNumber>
     {
-        internal Segment(
+        public Segment(
             IAlgebraicNumberCalculator<TAlgebraicNumber> calculator,
             Point<TAlgebraicNumber> start,
             Point<TAlgebraicNumber> end,

--- a/src/Hilke.KineticConvolution/Shape.cs
+++ b/src/Hilke.KineticConvolution/Shape.cs
@@ -5,7 +5,7 @@ namespace Hilke.KineticConvolution
 {
     public sealed class Shape<TAlgebraicNumber>
     {
-        internal Shape(IReadOnlyList<Tracing<TAlgebraicNumber>> tracings) => Tracings = tracings;
+        public Shape(IReadOnlyList<Tracing<TAlgebraicNumber>> tracings) => Tracings = tracings;
 
         public IReadOnlyList<Tracing<TAlgebraicNumber>> Tracings { get; }
     }


### PR DESCRIPTION
For intermediate projects, we need to be able to create points and segments without needing to rely on the convolution factory.