### PR TITLE
Shortest range of 180deg range is the clockwise range

### DIFF
--- a/src/Hilke.KineticConvolution/Direction.cs
+++ b/src/Hilke.KineticConvolution/Direction.cs
@@ -133,7 +133,7 @@ namespace Hilke.KineticConvolution
                     && _calculator.IsStrictlyPositive(Determinant(directions.End));
             }
 
-            if (_calculator.IsStrictlyNegative(determinant))
+            if (_calculator.IsNegative(determinant))
             {
                 return
                     _calculator.IsStrictlyNegative(directions.Start.Determinant(this))

--- a/src/Hilke.KineticConvolution/DirectionRange.cs
+++ b/src/Hilke.KineticConvolution/DirectionRange.cs
@@ -41,7 +41,7 @@ namespace Hilke.KineticConvolution
             Orientation switch
             {
                 Orientation.Clockwise =>
-                    _calculator.IsStrictlyNegative(Start.Determinant(End)),
+                    _calculator.IsNegative(Start.Determinant(End)),
                 Orientation.CounterClockwise =>
                     _calculator.IsStrictlyPositive(Start.Determinant(End)),
                 var orientation => throw new NotSupportedException(

--- a/tests/Hilke.KineticConvolution.Tests/DirectionRangeExtensionsTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/DirectionRangeExtensionsTests.cs
@@ -27,5 +27,26 @@ namespace Hilke.KineticConvolution.Tests
             range3.IsShortestRange().Should().BeFalse();
             range4.IsShortestRange().Should().BeTrue();
         }
+
+        [Test]
+        public void When_Direction_Range_Is_Exactly_A_Half_Plan_Then_The_Shortest_Range_Should_Be_Clockwise()
+        {
+            var factory = new ConvolutionFactory();
+
+            var d1 = factory.CreateDirection(1.0, 0.0);
+            var d2 = factory.CreateDirection(-1.0, 0.0);
+
+            var shortestRange1 = factory.CreateDirectionRange(d1, d2, Orientation.Clockwise);
+            var shortestRange2 = factory.CreateDirectionRange(d2, d1, Orientation.Clockwise);
+
+            var longestRange1 = factory.CreateDirectionRange(d1, d2, Orientation.CounterClockwise);
+            var longestRange2 = factory.CreateDirectionRange(d2, d1, Orientation.CounterClockwise);
+
+            shortestRange1.IsShortestRange().Should().BeTrue();
+            shortestRange2.IsShortestRange().Should().BeTrue();
+
+            longestRange1.IsShortestRange().Should().BeFalse();
+            longestRange2.IsShortestRange().Should().BeFalse();
+        }
     }
 }

--- a/tests/Hilke.KineticConvolution.Tests/DirectionTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/DirectionTests.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+
+using Hilke.KineticConvolution.DoubleAlgebraicNumber;
+
+using NUnit.Framework;
+
+namespace Hilke.KineticConvolution.Tests
+{
+    [TestFixture]
+    public class DirectionTests
+    {
+        [Test]
+        public void When_Direction_Is_Given_Then_It_Should_Belongs_To_The_Expected_Half_Plan()
+        {
+            var factory = new ConvolutionFactory();
+
+            var east = factory.CreateDirection(3.0, 0.0);
+            var west = factory.CreateDirection(-2.0, 0.0);
+
+            var lowerHalfPlan = factory.CreateDirectionRange(east, west, Orientation.Clockwise);
+            var upperHalfPlan = factory.CreateDirectionRange(east, west, Orientation.CounterClockwise);
+
+            var directionInUpperHalfPlan = factory.CreateDirection(-5.0, 0.5);
+            var directionInLowerHalfPlan = factory.CreateDirection(-5.0, -0.5);
+
+            directionInUpperHalfPlan.BelongsTo(lowerHalfPlan).Should().BeFalse();
+            directionInUpperHalfPlan.BelongsTo(upperHalfPlan).Should().BeTrue();
+
+            directionInLowerHalfPlan.BelongsTo(lowerHalfPlan).Should().BeTrue();
+            directionInLowerHalfPlan.BelongsTo(upperHalfPlan).Should().BeFalse();
+        }
+    }
+}


### PR DESCRIPTION
When a direction range spans exactly 180 degrees (i.e., it corresponds exactly to a half plan), then both ranges (clockwise and counterclockwise) have exactly the same 'size'. However, we need to adopt a convention that is used in `DirectionRange.IsShortestRange` and `Direction.BelongsToShortestRange` so that `Direction.BelongsTo` is well-defined.

The convention is that when both ranges have the same size, then the clockwise is the shortest. This choice is motivated by the convention that the counterclockwise orientation is positive (+1), and the clockwise orientation is negative (-1), hence clockwise < counterclockwise.

Accompanying unit tests validate these changes.