### PR TITLE
Fix the implementation of Direction.BelongsTo for the range boundaries

### DIFF
--- a/src/Hilke.KineticConvolution/ConvolutionFactory.cs
+++ b/src/Hilke.KineticConvolution/ConvolutionFactory.cs
@@ -8,11 +8,21 @@ namespace Hilke.KineticConvolution
 {
     public class ConvolutionFactory<TAlgebraicNumber> : IConvolutionFactory<TAlgebraicNumber>
     {
-        public ConvolutionFactory(IAlgebraicNumberCalculator<TAlgebraicNumber> algebraicNumberCalculator) =>
+        public ConvolutionFactory(IAlgebraicNumberCalculator<TAlgebraicNumber> algebraicNumberCalculator)
+        {
             AlgebraicNumberCalculator = algebraicNumberCalculator
                                      ?? throw new ArgumentNullException(nameof(algebraicNumberCalculator));
 
+            Zero = algebraicNumberCalculator.CreateConstant(0);
+
+            One = algebraicNumberCalculator.CreateConstant(1);
+        }
+
         public IAlgebraicNumberCalculator<TAlgebraicNumber> AlgebraicNumberCalculator { get; }
+
+        public TAlgebraicNumber Zero { get; }
+
+        public TAlgebraicNumber One { get; }
 
         public Point<TAlgebraicNumber> CreatePoint(TAlgebraicNumber x, TAlgebraicNumber y) =>
             new Point<TAlgebraicNumber>(AlgebraicNumberCalculator, x, y);

--- a/src/Hilke.KineticConvolution/Direction.cs
+++ b/src/Hilke.KineticConvolution/Direction.cs
@@ -143,11 +143,31 @@ namespace Hilke.KineticConvolution
             return false;
         }
 
+        public bool StrictlyBelongsTo(DirectionRange<TAlgebraicNumber> directions)
+        {
+            if (directions is null)
+            {
+                throw new ArgumentNullException(nameof(directions));
+            }
+
+            if (Equals(directions.Start) || Equals(directions.End))
+            {
+                return false;
+            }
+
+            return !(directions.IsShortestRange() ^ BelongsToShortestRange(directions));
+        }
+
         public bool BelongsTo(DirectionRange<TAlgebraicNumber> directions)
         {
             if (directions is null)
             {
                 throw new ArgumentNullException(nameof(directions));
+            }
+
+            if (Equals(directions.Start) || Equals(directions.End))
+            {
+                return true;
             }
 
             return !(directions.IsShortestRange() ^ BelongsToShortestRange(directions));

--- a/tests/Hilke.KineticConvolution.Tests/DirectionTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/DirectionTests.cs
@@ -29,5 +29,27 @@ namespace Hilke.KineticConvolution.Tests
             directionInLowerHalfPlan.BelongsTo(lowerHalfPlan).Should().BeTrue();
             directionInLowerHalfPlan.BelongsTo(upperHalfPlan).Should().BeFalse();
         }
+
+        [Test]
+        public void When_Direction_Is_One_DirectionRange_Extremity_Then_Direction_Should_Not_Belongs_Strictly_To_DirectionRange()
+        {
+            var factory = new ConvolutionFactory();
+
+            var east = factory.CreateDirection(1.0, 0.0);
+            var north = factory.CreateDirection(0.0, 1.0);
+
+            var directionRange1 = factory.CreateDirectionRange(east, north, Orientation.CounterClockwise);
+            var directionRange2 = factory.CreateDirectionRange(east, north, Orientation.Clockwise);
+
+            east.BelongsTo(directionRange1).Should().BeTrue();
+            east.BelongsTo(directionRange2).Should().BeTrue();
+            north.BelongsTo(directionRange1).Should().BeTrue();
+            north.BelongsTo(directionRange2).Should().BeTrue();
+
+            east.StrictlyBelongsTo(directionRange1).Should().BeFalse();
+            east.StrictlyBelongsTo(directionRange2).Should().BeFalse();
+            north.StrictlyBelongsTo(directionRange1).Should().BeFalse();
+            north.StrictlyBelongsTo(directionRange2).Should().BeFalse();
+        }
     }
 }


### PR DESCRIPTION
The implementation of `Direction.BelongsTo` did not handle properly and uniformly directions that are the `Start` or `End` of the direction range. The PR fix that, and add the unit test to confirm the fact.

Helper properties in `ConvolutionFactory<TAlgebaricNumber>` for the numeric constants one and zero.