### PR TITLE
Fix direction range intersection, add unit tests

### DIFF
--- a/src/Hilke.KineticConvolution/Arc.cs
+++ b/src/Hilke.KineticConvolution/Arc.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Diagnostics;
 
 using Fractions;
 
 namespace Hilke.KineticConvolution
 {
+    [DebuggerDisplay("Arc(Center: {Center}, {Directions}, Radius: {Radius}, Weight: {Weight})")]
     public sealed class Arc<TAlgebraicNumber> : Tracing<TAlgebraicNumber>
     {
         internal Arc(

--- a/src/Hilke.KineticConvolution/Arc.cs
+++ b/src/Hilke.KineticConvolution/Arc.cs
@@ -5,7 +5,7 @@ using Fractions;
 
 namespace Hilke.KineticConvolution
 {
-    [DebuggerDisplay("Arc(Center: {Center}, {Directions}, Radius: {Radius}, Weight: {Weight})")]
+    [DebuggerDisplay("Arc(Center: {Center}, Directions: {Directions}, Radius: {Radius}, Weight: {Weight})")]
     public sealed class Arc<TAlgebraicNumber> : Tracing<TAlgebraicNumber>
     {
         internal Arc(

--- a/src/Hilke.KineticConvolution/ConvolutionFactory.cs
+++ b/src/Hilke.KineticConvolution/ConvolutionFactory.cs
@@ -197,7 +197,8 @@ namespace Hilke.KineticConvolution
             {
                 return arc1.Directions.Intersection(arc2.Directions)
                            .Select(
-                               range => CreateArc(arc1.Center.Sum(arc2.Center),
+                               range => CreateArc(
+                                   arc1.Center.Sum(arc2.Center),
                                    range,
                                    AlgebraicNumberCalculator.Add(arc1.Radius, arc2.Radius),
                                    arc1.Weight * arc2.Weight))

--- a/src/Hilke.KineticConvolution/ConvolutionFactory.cs
+++ b/src/Hilke.KineticConvolution/ConvolutionFactory.cs
@@ -61,21 +61,21 @@ namespace Hilke.KineticConvolution
         }
 
         public Segment<TAlgebraicNumber> CreateSegment(
-            Fraction weight,
             TAlgebraicNumber startX,
             TAlgebraicNumber startY,
             TAlgebraicNumber endX,
-            TAlgebraicNumber endY) =>
+            TAlgebraicNumber endY,
+            Fraction weight) =>
             CreateSegment(
                 CreatePoint(startX, startY),
                 CreatePoint(endX, endY),
                 weight);
 
         public Arc<TAlgebraicNumber> CreateArc(
-            Fraction weight,
             Point<TAlgebraicNumber> center,
             DirectionRange<TAlgebraicNumber> directions,
-            TAlgebraicNumber radius)
+            TAlgebraicNumber radius,
+            Fraction weight)
         {
             if (center is null)
             {
@@ -118,7 +118,6 @@ namespace Hilke.KineticConvolution
         }
 
         public Arc<TAlgebraicNumber> CreateArc(
-            Fraction weight,
             TAlgebraicNumber centerX,
             TAlgebraicNumber centerY,
             TAlgebraicNumber directionStartX,
@@ -126,15 +125,16 @@ namespace Hilke.KineticConvolution
             TAlgebraicNumber directionEndX,
             TAlgebraicNumber directionEndY,
             Orientation orientation,
-            TAlgebraicNumber radius) =>
+            TAlgebraicNumber radius,
+            Fraction weight) =>
             CreateArc(
-                weight,
                 CreatePoint(centerX, centerY),
                 CreateDirectionRange(
                     CreateDirection(directionStartX, directionStartY),
                     CreateDirection(directionEndX, directionEndY),
                     orientation),
-                radius);
+                radius,
+                weight);
 
         public Convolution<TAlgebraicNumber> ConvolveShapes(
             Shape<TAlgebraicNumber> shape1,
@@ -197,11 +197,10 @@ namespace Hilke.KineticConvolution
             {
                 return arc1.Directions.Intersection(arc2.Directions)
                            .Select(
-                               range => CreateArc(
-                                   arc1.Weight * arc2.Weight,
-                                   arc1.Center.Sum(arc2.Center),
+                               range => CreateArc(arc1.Center.Sum(arc2.Center),
                                    range,
-                                   AlgebraicNumberCalculator.Add(arc1.Radius, arc2.Radius)))
+                                   AlgebraicNumberCalculator.Add(arc1.Radius, arc2.Radius),
+                                   arc1.Weight * arc2.Weight))
                            .Select(arc => new ConvolvedTracing<TAlgebraicNumber>(arc, arc1, arc2));
             }
 
@@ -210,12 +209,12 @@ namespace Hilke.KineticConvolution
                 {
                     var signedRadius = AlgebraicNumberCalculator.Subtract(arc1.Radius, arc2.Radius);
                     return CreateArc(
-                        arc1.Weight * arc2.Weight,
                         arc1.Center.Sum(arc2.Center),
                         AlgebraicNumberCalculator.IsStrictlyNegative(signedRadius)
                             ? range.Opposite()
                             : range,
-                        Abs(signedRadius));
+                        Abs(signedRadius),
+                        arc1.Weight * arc2.Weight);
                 })
                 .Select(arc => new ConvolvedTracing<TAlgebraicNumber>(arc, arc1, arc2));
         }

--- a/src/Hilke.KineticConvolution/ConvolvedTracing.cs
+++ b/src/Hilke.KineticConvolution/ConvolvedTracing.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Diagnostics;
 
 namespace Hilke.KineticConvolution
 {
+    [DebuggerDisplay("Convolution(Convolution: {Convolution}, Parent1: {Parent1}, Parent2: {Parent2})")]
     public sealed class ConvolvedTracing<TAlgebraicNumber>
     {
         public ConvolvedTracing(

--- a/src/Hilke.KineticConvolution/Direction.cs
+++ b/src/Hilke.KineticConvolution/Direction.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Diagnostics;
 
 namespace Hilke.KineticConvolution
 {
+    [DebuggerDisplay("Direction({X}, {Y})")]
     public sealed class Direction<TAlgebraicNumber> : IEquatable<Direction<TAlgebraicNumber>>
     {
         private readonly IAlgebraicNumberCalculator<TAlgebraicNumber> _calculator;

--- a/src/Hilke.KineticConvolution/Direction.cs
+++ b/src/Hilke.KineticConvolution/Direction.cs
@@ -215,7 +215,7 @@ namespace Hilke.KineticConvolution
         {
             unchecked
             {
-                return (X.GetHashCode() * 397) ^ Y.GetHashCode();
+                return (X!.GetHashCode() * 397) ^ Y!.GetHashCode();
             }
         }
 

--- a/src/Hilke.KineticConvolution/DirectionRange.cs
+++ b/src/Hilke.KineticConvolution/DirectionRange.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Hilke.KineticConvolution
 {
-    [DebuggerDisplay("DirectionRange: Start {Start} End {End} Orientation: {Orientation}")]
+    [DebuggerDisplay("DirectionRange(Start: {Start}, End: {End}, Orientation: {Orientation})")]
     public sealed class DirectionRange<TAlgebraicNumber>
     {
         private readonly IAlgebraicNumberCalculator<TAlgebraicNumber> _calculator;

--- a/src/Hilke.KineticConvolution/DirectionRange.cs
+++ b/src/Hilke.KineticConvolution/DirectionRange.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Hilke.KineticConvolution
 {
-    [DebuggerDisplay("DirectionRange: Start ({Start.X}, {Start.Y}) - End ({End.X}, {End.Y}); Orientation: {Orientation}")]
+    [DebuggerDisplay("DirectionRange: Start {Start} End {End} Orientation: {Orientation}")]
     public sealed class DirectionRange<TAlgebraicNumber>
     {
         private readonly IAlgebraicNumberCalculator<TAlgebraicNumber> _calculator;

--- a/src/Hilke.KineticConvolution/DirectionRange.cs
+++ b/src/Hilke.KineticConvolution/DirectionRange.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Hilke.KineticConvolution
 {
+    [DebuggerDisplay("DirectionRange: Start ({Start.X}, {Start.Y}) - End ({End.X}, {End.Y}); Orientation: {Orientation}")]
     public sealed class DirectionRange<TAlgebraicNumber>
     {
         private readonly IAlgebraicNumberCalculator<TAlgebraicNumber> _calculator;

--- a/src/Hilke.KineticConvolution/DirectionRange.cs
+++ b/src/Hilke.KineticConvolution/DirectionRange.cs
@@ -104,11 +104,14 @@ namespace Hilke.KineticConvolution
 
             if (range.Start.BelongsTo(this))
             {
-                yield return new DirectionRange<TAlgebraicNumber>(
-                    _calculator,
-                    range.Start,
-                    Start.FirstOf(End, range.End),
-                    Orientation.CounterClockwise);
+                if (range.Start != End)
+                {
+                    yield return new DirectionRange<TAlgebraicNumber>(
+                        _calculator,
+                        range.Start,
+                        Start.FirstOf(End, range.End),
+                        Orientation.CounterClockwise);
+                }
 
                 if (Start.CompareTo(range.Start, range.End) == DirectionOrder.Before
                  && End.CompareTo(range.End, Start) == DirectionOrder.Before)

--- a/src/Hilke.KineticConvolution/IConvolutionFactory.cs
+++ b/src/Hilke.KineticConvolution/IConvolutionFactory.cs
@@ -8,6 +8,10 @@ namespace Hilke.KineticConvolution
     {
         IAlgebraicNumberCalculator<TAlgebraicNumber> AlgebraicNumberCalculator { get; }
 
+        TAlgebraicNumber Zero { get; }
+
+        TAlgebraicNumber One { get; }
+
         Point<TAlgebraicNumber> CreatePoint(TAlgebraicNumber x, TAlgebraicNumber y);
 
         Direction<TAlgebraicNumber> CreateDirection(TAlgebraicNumber x, TAlgebraicNumber y);
@@ -22,21 +26,20 @@ namespace Hilke.KineticConvolution
             Point<TAlgebraicNumber> end,
             Fraction weight);
 
-        public Segment<TAlgebraicNumber> CreateSegment(
-            Fraction weight,
+        Segment<TAlgebraicNumber> CreateSegment(
             TAlgebraicNumber startX,
             TAlgebraicNumber startY,
             TAlgebraicNumber endX,
-            TAlgebraicNumber endY);
+            TAlgebraicNumber endY,
+            Fraction weight);
 
         Arc<TAlgebraicNumber> CreateArc(
-            Fraction weight,
             Point<TAlgebraicNumber> center,
             DirectionRange<TAlgebraicNumber> directions,
-            TAlgebraicNumber radius);
+            TAlgebraicNumber radius,
+            Fraction weight);
 
         Arc<TAlgebraicNumber> CreateArc(
-            Fraction weight,
             TAlgebraicNumber centerX,
             TAlgebraicNumber centerY,
             TAlgebraicNumber directionStartX,
@@ -44,7 +47,8 @@ namespace Hilke.KineticConvolution
             TAlgebraicNumber directionEndX,
             TAlgebraicNumber directionEndY,
             Orientation orientation,
-            TAlgebraicNumber radius);
+            TAlgebraicNumber radius,
+            Fraction weight);
 
         Convolution<TAlgebraicNumber> ConvolveShapes(
             Shape<TAlgebraicNumber> shape1,

--- a/src/Hilke.KineticConvolution/Point.cs
+++ b/src/Hilke.KineticConvolution/Point.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Diagnostics;
 
 namespace Hilke.KineticConvolution
 {
+    [DebuggerDisplay("({X}, {Y})")]
     public sealed class Point<TAlgebraicNumber> : IEquatable<Point<TAlgebraicNumber>>
     {
         private readonly IAlgebraicNumberCalculator<TAlgebraicNumber> _calculator;

--- a/src/Hilke.KineticConvolution/Point.cs
+++ b/src/Hilke.KineticConvolution/Point.cs
@@ -30,8 +30,8 @@ namespace Hilke.KineticConvolution
                 return true;
             }
 
-            return X.Equals(other.X)
-                && Y.Equals(other.Y);
+            return X!.Equals(other.X)
+                && Y!.Equals(other.Y);
         }
 
         public Point<TAlgebraicNumber> Translate(Direction<TAlgebraicNumber> direction, TAlgebraicNumber length)
@@ -79,7 +79,7 @@ namespace Hilke.KineticConvolution
         {
             unchecked
             {
-                return (X.GetHashCode() * 397) ^ Y.GetHashCode();
+                return (X!.GetHashCode() * 397) ^ Y!.GetHashCode();
             }
         }
 

--- a/src/Hilke.KineticConvolution/Segment.cs
+++ b/src/Hilke.KineticConvolution/Segment.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Diagnostics;
 
 using Fractions;
 
 namespace Hilke.KineticConvolution
 {
+    [DebuggerDisplay("Segment Start: {Start} End: {End} StartDirection: {StartDirection} EndDirection: {EndDirection} Weight: {Weight}")]
     public sealed class Segment<TAlgebraicNumber> : Tracing<TAlgebraicNumber>
     {
         internal Segment(

--- a/src/Hilke.KineticConvolution/Segment.cs
+++ b/src/Hilke.KineticConvolution/Segment.cs
@@ -5,7 +5,7 @@ using Fractions;
 
 namespace Hilke.KineticConvolution
 {
-    [DebuggerDisplay("Segment Start: {Start} End: {End} StartDirection: {StartDirection} EndDirection: {EndDirection} Weight: {Weight}")]
+    [DebuggerDisplay("Segment(Start: {Start}, End: {End}, StartDirection: {StartDirection}, EndDirection: {EndDirection}, Weight: {Weight})")]
     public sealed class Segment<TAlgebraicNumber> : Tracing<TAlgebraicNumber>
     {
         internal Segment(

--- a/src/Hilke.KineticConvolution/Segment.cs
+++ b/src/Hilke.KineticConvolution/Segment.cs
@@ -1,11 +1,10 @@
-using System;
 using System.Diagnostics;
 
 using Fractions;
 
 namespace Hilke.KineticConvolution
 {
-    [DebuggerDisplay("Segment(Start: {Start}, End: {End}, StartDirection: {StartDirection}, EndDirection: {EndDirection}, Weight: {Weight})")]
+    [DebuggerDisplay("Segment(Start: {Start}, End: {End}, Direction: {StartDirection}, Weight: {Weight})")]
     public sealed class Segment<TAlgebraicNumber> : Tracing<TAlgebraicNumber>
     {
         internal Segment(

--- a/tests/Hilke.KineticConvolution.Tests/ConvolutionHelperTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/ConvolutionHelperTests.cs
@@ -20,26 +20,26 @@ namespace Hilke.KineticConvolution.Tests
             var convolutionFactory = new ConvolutionFactory();
 
             var arc1 = convolutionFactory.CreateArc(
-                1,
-                1.0,
-                2.0,
-                1.0,
-                0.0,
-                0.0,
-                1.0,
-                Orientation.CounterClockwise,
-                radius1);
+                centerX: 1.0,
+                centerY: 2.0,
+                directionStartX: 1.0,
+                directionStartY: 0.0,
+                directionEndX: 0.0,
+                directionEndY: 1.0,
+                orientation: Orientation.CounterClockwise,
+                radius: radius1,
+                weight: 1);
 
             var arc2 = convolutionFactory.CreateArc(
-                1,
-                2.0,
-                1.0,
-                1.0,
-                0.5,
-                0.5,
-                1.0,
-                Orientation.CounterClockwise,
-                radius2);
+                centerX: 2.0,
+                centerY: 1.0,
+                directionStartX: 1.0,
+                directionStartY: 0.5,
+                directionEndX: 0.5,
+                directionEndY: 1.0,
+                orientation: Orientation.CounterClockwise,
+                radius: radius2,
+                weight: 1);
 
             var convolution = convolutionFactory.Convolve(arc1, arc2).ToList();
 

--- a/tests/Hilke.KineticConvolution.Tests/DirectionRangeExtensionsTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/DirectionRangeExtensionsTests.cs
@@ -4,8 +4,32 @@ using Hilke.KineticConvolution.DoubleAlgebraicNumber;
 
 using NUnit.Framework;
 
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Hilke.KineticConvolution.Tests
 {
+    internal class DirectionRangeTestCaseDataSource
+    {
+        public static IEnumerable<TestCaseData> TestCases()
+        {
+            var factory = new ConvolutionFactory();
+
+            yield return new TestCaseData(
+                Orientation.CounterClockwise, Enumerable.Empty<DirectionRange<double>>());
+
+            yield return new TestCaseData(
+                Orientation.Clockwise,
+                new []
+                {
+                    factory.CreateDirectionRange(
+                        factory.CreateDirection(0, 1),
+                        factory.CreateDirection(0, -1),
+                        Orientation.Clockwise)
+                });
+        }
+    }
+
     [TestFixture]
     public class DirectionRangeExtensionsTests
     {
@@ -47,6 +71,26 @@ namespace Hilke.KineticConvolution.Tests
 
             longestRange1.IsShortestRange().Should().BeFalse();
             longestRange2.IsShortestRange().Should().BeFalse();
+        }
+
+        [TestCaseSource(
+            typeof(DirectionRangeTestCaseDataSource),
+            nameof(DirectionRangeTestCaseDataSource.TestCases))]
+        public void When_Start_Direction_Coincide_With_End_Then_Expected_Range_Should_Be_Returned(
+            Orientation orientation,
+            IEnumerable<DirectionRange<double>> expectedRange)
+        {
+            var factory = new ConvolutionFactory();
+
+            var d1 = factory.CreateDirection(0.0, 1.0);
+            var d2 = factory.CreateDirection(0.0, -1.0);
+
+            var leftHalfPlan = factory.CreateDirectionRange(d1, d2, Orientation.Clockwise);
+            var rightHalfPlan = factory.CreateDirectionRange(d1, d2, orientation);
+
+            var intersection = leftHalfPlan.Intersection(rightHalfPlan);
+
+            intersection.Should().BeEquivalentTo(expectedRange);
         }
     }
 }

--- a/tests/Hilke.KineticConvolution.Tests/DirectionRangeExtensionsTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/DirectionRangeExtensionsTests.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace Hilke.KineticConvolution.Tests
 {
-    internal class DirectionRangeTestCaseDataSource
+    internal static class DirectionRangeTestCaseDataSource
     {
         public static IEnumerable<TestCaseData> TestCases()
         {


### PR DESCRIPTION
The intersection of direction ranges did not handle properly the case where the start of the second range is exactly equal to the end of the first range. 

The PR fixes this, add corresponding unit tests, and homogeneise the parameter order in the factory.