### PR TITLE
15908 fix point comparison

### DIFF
--- a/src/Hilke.KineticConvolution/AlgebraicNumberCalculatorExtensions.cs
+++ b/src/Hilke.KineticConvolution/AlgebraicNumberCalculatorExtensions.cs
@@ -63,5 +63,99 @@ namespace Hilke.KineticConvolution
 
             return calculator.Sign(number) <= 0;
         }
+
+        public static bool IsSmallerThan<TAlgebraicNumber>(
+            this IAlgebraicNumberCalculator<TAlgebraicNumber> calculator,
+            TAlgebraicNumber number1,
+            TAlgebraicNumber number2)
+        {
+            if (calculator is null)
+            {
+                throw new ArgumentNullException(nameof(calculator));
+            }
+
+            return calculator.IsPositive(calculator.Subtract(number2, number1));
+        }
+
+        public static bool IsGreaterThan<TAlgebraicNumber>(
+            this IAlgebraicNumberCalculator<TAlgebraicNumber> calculator,
+            TAlgebraicNumber number1,
+            TAlgebraicNumber number2)
+        {
+            if (calculator is null)
+            {
+                throw new ArgumentNullException(nameof(calculator));
+            }
+
+            return calculator.IsNegative(calculator.Subtract(number2, number1));
+        }
+
+        public static bool IsStrictlySmallerThan<TAlgebraicNumber>(
+            this IAlgebraicNumberCalculator<TAlgebraicNumber> calculator,
+            TAlgebraicNumber number1,
+            TAlgebraicNumber number2)
+        {
+            if (calculator is null)
+            {
+                throw new ArgumentNullException(nameof(calculator));
+            }
+
+            return calculator.IsStrictlyPositive(calculator.Subtract(number2, number1));
+        }
+
+        public static bool IsStrictlyGreaterThan<TAlgebraicNumber>(
+            this IAlgebraicNumberCalculator<TAlgebraicNumber> calculator,
+            TAlgebraicNumber number1,
+            TAlgebraicNumber number2)
+        {
+            if (calculator is null)
+            {
+                throw new ArgumentNullException(nameof(calculator));
+            }
+
+            return calculator.IsStrictlyNegative(calculator.Subtract(number2, number1));
+        }
+
+        public static TAlgebraicNumber Abs<TAlgebraicNumber>(
+            this IAlgebraicNumberCalculator<TAlgebraicNumber> calculator,
+            TAlgebraicNumber number)
+        {
+            if (calculator is null)
+            {
+                throw new ArgumentNullException(nameof(calculator));
+            }
+
+            return calculator.IsStrictlyNegative(number)
+                ? calculator.Opposite(number)
+                : number;
+        }
+
+        public static bool AreEqual<TAlgebraicNumber>(
+            this IAlgebraicNumberCalculator<TAlgebraicNumber> calculator,
+            TAlgebraicNumber number1,
+            TAlgebraicNumber number2)
+        {
+            if (calculator is null)
+            {
+                throw new ArgumentNullException(nameof(calculator));
+            }
+
+            return calculator.IsZero(calculator.Subtract(number2, number1));
+        }
+
+        public static bool AreClose<TAlgebraicNumber>(
+            this IAlgebraicNumberCalculator<TAlgebraicNumber> calculator,
+            TAlgebraicNumber number1,
+            TAlgebraicNumber number2,
+            TAlgebraicNumber tolerance)
+        {
+            if (calculator is null)
+            {
+                throw new ArgumentNullException(nameof(calculator));
+            }
+
+            var absoluteDifference = calculator.Abs(calculator.Subtract(number2, number1));
+            return calculator.IsSmallerThan(absoluteDifference, tolerance);
+        }
     }
 }

--- a/src/Hilke.KineticConvolution/AlgebraicNumberCalculatorExtensions.cs
+++ b/src/Hilke.KineticConvolution/AlgebraicNumberCalculatorExtensions.cs
@@ -157,5 +157,78 @@ namespace Hilke.KineticConvolution
             var absoluteDifference = calculator.Abs(calculator.Subtract(number2, number1));
             return calculator.IsSmallerThan(absoluteDifference, tolerance);
         }
+
+        public static TAlgebraicNumber Min<TAlgebraicNumber>(
+            this IAlgebraicNumberCalculator<TAlgebraicNumber> calculator,
+            TAlgebraicNumber first,
+            TAlgebraicNumber second)
+        {
+            if (calculator is null)
+            {
+                throw new ArgumentNullException(nameof(calculator));
+            }
+
+            return calculator.IsStrictlySmallerThan(first, second) ? first : second;
+        }
+
+        public static TAlgebraicNumber Max<TAlgebraicNumber>(
+            this IAlgebraicNumberCalculator<TAlgebraicNumber> calculator,
+            TAlgebraicNumber first,
+            TAlgebraicNumber second)
+        {
+            if (calculator is null)
+            {
+                throw new ArgumentNullException(nameof(calculator));
+            }
+
+            return calculator.IsStrictlySmallerThan(first, second) ? second : first;
+        }
+
+        public static (TAlgebraicNumber first, TAlgebraicNumber second)
+            Sort<TAlgebraicNumber>(
+                this IAlgebraicNumberCalculator<TAlgebraicNumber> calculator,
+                TAlgebraicNumber first,
+                TAlgebraicNumber second)
+        {
+            if (calculator is null)
+            {
+                throw new ArgumentNullException(nameof(calculator));
+            }
+
+            return calculator.IsStrictlySmallerThan(first, second) ? (first, second) : (second, first);
+        }
+
+        public static bool IsInsideRange<TAlgebraicNumber>(
+            this IAlgebraicNumberCalculator<TAlgebraicNumber> calculator,
+            TAlgebraicNumber number,
+            TAlgebraicNumber lowerBound,
+            TAlgebraicNumber upperBound,
+            bool lowerBoundIncluded = true,
+            bool upperBoundIncluded = true)
+        {
+            if (calculator is null)
+            {
+                throw new ArgumentNullException(nameof(calculator));
+            }
+
+            var isGreaterThanLowerBound =
+                lowerBoundIncluded
+                    ? calculator.IsGreaterThan(number, lowerBound)
+                    : calculator.IsStrictlyGreaterThan(number, lowerBound);
+
+            var isSmallerThanUpperBound =
+                upperBoundIncluded
+                    ? calculator.IsSmallerThan(number, upperBound)
+                    : calculator.IsStrictlySmallerThan(number, lowerBound);
+
+            return isGreaterThanLowerBound && isSmallerThanUpperBound;
+        }
+
+        public static bool IsStrictlyInsideRange<TAlgebraicNumber>(
+            this IAlgebraicNumberCalculator<TAlgebraicNumber> calculator,
+            TAlgebraicNumber number,
+            TAlgebraicNumber lowerBound,
+            TAlgebraicNumber upperBound) =>
+            IsInsideRange(calculator, number, lowerBound, upperBound, false, false);
     }
 }

--- a/src/Hilke.KineticConvolution/Direction.cs
+++ b/src/Hilke.KineticConvolution/Direction.cs
@@ -185,7 +185,7 @@ namespace Hilke.KineticConvolution
             new Direction<TAlgebraicNumber>(_calculator, _calculator.Opposite(Y), X);
 
         /// <inheritdoc />
-        public override bool Equals (object? other)
+        public override bool Equals(object? other)
         {
             if (other is null)
             {
@@ -195,11 +195,6 @@ namespace Hilke.KineticConvolution
             if (ReferenceEquals(this, other))
             {
                 return true;
-            }
-
-            if (GetType() != other.GetType())
-            {
-                return false;
             }
 
             if (other is Direction<TAlgebraicNumber> direction)

--- a/src/Hilke.KineticConvolution/Direction.cs
+++ b/src/Hilke.KineticConvolution/Direction.cs
@@ -48,24 +48,7 @@ namespace Hilke.KineticConvolution
         /// <inheritdoc />
         public bool Equals(Direction<TAlgebraicNumber>? other)
         {
-            if (other is null)
-            {
-                return false;
-            }
-
-            if (ReferenceEquals(this, other))
-            {
-                return true;
-            }
-
-            if (GetType() != other.GetType())
-            {
-                return false;
-            }
-
-            return _calculator.IsZero(Determinant(other))
-                && _calculator.Sign(X) == _calculator.Sign(other.X)
-                && _calculator.Sign(Y) == _calculator.Sign(other.Y);
+            return Equals(other as object);
         }
 
         public TAlgebraicNumber Determinant(Direction<TAlgebraicNumber> other)
@@ -202,11 +185,28 @@ namespace Hilke.KineticConvolution
             new Direction<TAlgebraicNumber>(_calculator, _calculator.Opposite(Y), X);
 
         /// <inheritdoc />
-        public override bool Equals(object? obj)
+        public override bool Equals (object? other)
         {
-            if (obj is Direction<TAlgebraicNumber> direction)
+            if (other is null)
             {
-                return Equals(direction);
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            if (GetType() != other.GetType())
+            {
+                return false;
+            }
+
+            if (other is Direction<TAlgebraicNumber> direction)
+            {
+                return _calculator.IsZero(Determinant(direction))
+                    && _calculator.Sign(X) == _calculator.Sign(direction.X)
+                    && _calculator.Sign(Y) == _calculator.Sign(direction.Y);
             }
 
             return false;

--- a/src/Hilke.KineticConvolution/Point.cs
+++ b/src/Hilke.KineticConvolution/Point.cs
@@ -22,18 +22,7 @@ namespace Hilke.KineticConvolution
         /// <inheritdoc />
         public bool Equals(Point<TAlgebraicNumber>? other)
         {
-            if (other is null)
-            {
-                return false;
-            }
-
-            if (ReferenceEquals(this, other))
-            {
-                return true;
-            }
-
-            return X!.Equals(other.X)
-                && Y!.Equals(other.Y);
+            return Equals(other as object);
         }
 
         public Point<TAlgebraicNumber> Translate(Direction<TAlgebraicNumber> direction, TAlgebraicNumber length)
@@ -56,21 +45,22 @@ namespace Hilke.KineticConvolution
             new Point<TAlgebraicNumber>(_calculator, _calculator.Add(X, point2.X), _calculator.Add(Y, point2.Y));
 
         /// <inheritdoc />
-        public override bool Equals(object? obj)
+        public override bool Equals(object? other)
         {
-            if (obj is null)
+            if (other is null)
             {
                 return false;
             }
 
-            if (ReferenceEquals(this, obj))
+            if (ReferenceEquals(this, other))
             {
                 return true;
             }
 
-            if (obj is Point<TAlgebraicNumber> point)
+            if (other is Point<TAlgebraicNumber> point)
             {
-                return Equals(point);
+                return _calculator.AreEqual(X, point.X)
+                && _calculator.AreEqual(Y, point.Y);
             }
 
             return false;

--- a/src/Hilke.KineticConvolution/Point.cs
+++ b/src/Hilke.KineticConvolution/Point.cs
@@ -57,15 +57,10 @@ namespace Hilke.KineticConvolution
                 return true;
             }
 
-            if (GetType() != other.GetType())
-            {
-                return false;
-            }
-
             if (other is Point<TAlgebraicNumber> point)
             {
                 return _calculator.AreEqual(X, point.X)
-                && _calculator.AreEqual(Y, point.Y);
+                    && _calculator.AreEqual(Y, point.Y);
             }
 
             return false;

--- a/src/Hilke.KineticConvolution/Point.cs
+++ b/src/Hilke.KineticConvolution/Point.cs
@@ -57,6 +57,11 @@ namespace Hilke.KineticConvolution
                 return true;
             }
 
+            if (GetType() != other.GetType())
+            {
+                return false;
+            }
+
             if (other is Point<TAlgebraicNumber> point)
             {
                 return _calculator.AreEqual(X, point.X)

--- a/tests/Hilke.KineticConvolution.Tests/AlgebraicNumberCalculatorExtensionsTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/AlgebraicNumberCalculatorExtensionsTests.cs
@@ -30,8 +30,7 @@ namespace Hilke.KineticConvolution.Tests
             var number2 = _calculator.CreateConstant(doubleNumber2);
 
             // Act
-            var comparison =
-                _calculator.IsSmallerThan(number1, number2);
+            var comparison = _calculator.IsSmallerThan(number1, number2);
 
             // Assert
             comparison.Should().BeTrue();
@@ -65,8 +64,7 @@ namespace Hilke.KineticConvolution.Tests
             var number2 = _calculator.CreateConstant(doubleNumber2);
 
             // Act
-            var comparison =
-                _calculator.IsGreaterThan(number1, number2);
+            var comparison = _calculator.IsGreaterThan(number1, number2);
 
             // Assert
             comparison.Should().BeTrue();
@@ -99,8 +97,7 @@ namespace Hilke.KineticConvolution.Tests
             var number2 = _calculator.CreateConstant(doubleNumber2);
 
             // Act
-            var comparison =
-                _calculator.IsStrictlyGreaterThan(number1, number2);
+            var comparison = _calculator.IsStrictlyGreaterThan(number1, number2);
 
             // Assert
             comparison.Should().BeTrue();
@@ -134,8 +131,7 @@ namespace Hilke.KineticConvolution.Tests
             var number2 = _calculator.CreateConstant(doubleNumber2);
 
             // Act
-            var comparison =
-                _calculator.IsStrictlySmallerThan(number1, number2);
+            var comparison = _calculator.IsStrictlySmallerThan(number1, number2);
 
             // Assert
             comparison.Should().BeTrue();

--- a/tests/Hilke.KineticConvolution.Tests/AlgebraicNumberCalculatorExtensionsTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/AlgebraicNumberCalculatorExtensionsTests.cs
@@ -211,5 +211,47 @@ namespace Hilke.KineticConvolution.Tests
             // Assert
             number1IsCloseToNumber2.Should().Be(numberAreCloseExpectation);
         }
+
+        [TestCase(-1, 1, ExpectedResult = -1)]
+        [TestCase(1, 1, ExpectedResult = 1)]
+        [TestCase(1, -1, ExpectedResult = -1)]
+        public double When_Calling_Min_Given_Parameter_Should_Return_Expected_Result(
+            double number1, double number2) =>
+            _calculator.Min(number1, number2);
+
+        [TestCase(-1, 1, ExpectedResult = 1)]
+        [TestCase(1, 1, ExpectedResult = 1)]
+        [TestCase(1, -1, ExpectedResult = 1)]
+        public double When_Calling_Max_Given_Parameter_Should_Return_Expected_Result(
+            double number1, double number2) =>
+            _calculator.Max(number1, number2);
+
+        [TestCase(-1.0, 1.0)]
+        [TestCase(2.0, 2.0)]
+        [TestCase(0.0, 0.0)]
+        [TestCase(1.0, -10.0)]
+        public void When_Calling_Sort_Given_Parameter_Should_Return_Expected_Result(
+            double number1, double number2)
+        {
+            // Act
+            var pair = _calculator.Sort(number1, number2);
+
+            // Assert
+            pair.Item1.Should().BeLessOrEqualTo(pair.Item2);
+        }
+
+        [TestCase(-2, -3, -1, ExpectedResult = true)]
+        [TestCase(-2, -1, -3, ExpectedResult = false)]
+        [TestCase(-1, -2, -3, ExpectedResult = false)]
+        [TestCase(-1, -3, -2, ExpectedResult = false)]
+        [TestCase(2, 3, 1, ExpectedResult = false)]
+        [TestCase(2, 1, 3, ExpectedResult = true)]
+        [TestCase(1, 2, 3, ExpectedResult = false)]
+        [TestCase(1, 3, 2, ExpectedResult = false)]
+        public bool When_Calling_IsInsideRange_Given_Parameter_Should_Return_Expected_Result(
+            double number,
+            double lowerBound,
+            double higherBound) =>
+            _calculator.IsInsideRange(number, lowerBound, higherBound);
     }
 }

--- a/tests/Hilke.KineticConvolution.Tests/AlgebraicNumberCalculatorExtensionsTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/AlgebraicNumberCalculatorExtensionsTests.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-
 using FluentAssertions;
 
 using Hilke.KineticConvolution.DoubleAlgebraicNumber;
@@ -11,6 +9,15 @@ namespace Hilke.KineticConvolution.Tests
     [TestFixture]
     public class AlgebraicNumberCalculatorTests
     {
+        private IAlgebraicNumberCalculator<double> _calculator;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var factory = new ConvolutionFactory();
+            _calculator = factory.AlgebraicNumberCalculator;
+        }
+
         [TestCase(0.0, 0.0)]
         [TestCase(0.0, 1.0)]
         [TestCase(-1.0, 0.0)]
@@ -18,19 +25,15 @@ namespace Hilke.KineticConvolution.Tests
         public void When_Number1_Is_Smaller_Than_Number2_Then_IsSmallerThan_Should_Return_True(
             double doubleNumber1, double doubleNumber2)
         {
-            // arrange
-            var factory = new ConvolutionFactory();
+            // Arrange
+            var number1 = _calculator.CreateConstant(doubleNumber1);
+            var number2 = _calculator.CreateConstant(doubleNumber2);
 
-            var calculator = factory.AlgebraicNumberCalculator;
-
-            var number1 = calculator.CreateConstant(doubleNumber1);
-            var number2 = calculator.CreateConstant(doubleNumber2);
-
-            // act
+            // Act
             var comparison =
-                calculator.IsSmallerThan(number1, number2);
+                _calculator.IsSmallerThan(number1, number2);
 
-            // assert
+            // Assert
             comparison.Should().BeTrue();
         }
 
@@ -39,18 +42,14 @@ namespace Hilke.KineticConvolution.Tests
         public void When_Number1_Is_Strictly_Greater_Than_Number2_Then_IsSmallerThan_Should_Return_False(
             double doubleNumber1, double doubleNumber2)
         {
-            // arrange
-            var factory = new ConvolutionFactory();
+            // Arrange
+            var number1 = _calculator.CreateConstant(doubleNumber1);
+            var number2 = _calculator.CreateConstant(doubleNumber2);
 
-            var calculator = factory.AlgebraicNumberCalculator;
+            // Act
+            var comparison = _calculator.IsSmallerThan(number1, number2);
 
-            var number1 = calculator.CreateConstant(doubleNumber1);
-            var number2 = calculator.CreateConstant(doubleNumber2);
-
-            // act
-            var comparison = calculator.IsSmallerThan(number1, number2);
-
-            // assert
+            // Assert
             comparison.Should().BeFalse();
         }
 
@@ -61,19 +60,15 @@ namespace Hilke.KineticConvolution.Tests
         public void When_Number1_Is_Greater_Than_Number2_Then_IsGreaterThan_Should_Return_True(
             double doubleNumber1, double doubleNumber2)
         {
-            // arrange
-            var factory = new ConvolutionFactory();
+            // Arrange
+            var number1 = _calculator.CreateConstant(doubleNumber1);
+            var number2 = _calculator.CreateConstant(doubleNumber2);
 
-            var calculator = factory.AlgebraicNumberCalculator;
-
-            var number1 = calculator.CreateConstant(doubleNumber1);
-            var number2 = calculator.CreateConstant(doubleNumber2);
-
-            // act
+            // Act
             var comparison =
-                calculator.IsGreaterThan(number1, number2);
+                _calculator.IsGreaterThan(number1, number2);
 
-            // assert
+            // Assert
             comparison.Should().BeTrue();
         }
 
@@ -82,18 +77,14 @@ namespace Hilke.KineticConvolution.Tests
         public void When_Number1_Is_Strictly_Smaller_Than_Number2_Then_IsGreaterThan_Should_Return_False(
             double doubleNumber1, double doubleNumber2)
         {
-            // arrange
-            var factory = new ConvolutionFactory();
+            // Arrange
+            var number1 = _calculator.CreateConstant(doubleNumber1);
+            var number2 = _calculator.CreateConstant(doubleNumber2);
 
-            var calculator = factory.AlgebraicNumberCalculator;
+            // Act
+            var comparison = _calculator.IsGreaterThan(number1, number2);
 
-            var number1 = calculator.CreateConstant(doubleNumber1);
-            var number2 = calculator.CreateConstant(doubleNumber2);
-
-            // act
-            var comparison = calculator.IsGreaterThan(number1, number2);
-
-            // assert
+            // Assert
             comparison.Should().BeFalse();
         }
 
@@ -103,19 +94,15 @@ namespace Hilke.KineticConvolution.Tests
         public void When_Number1_Is_Strictly_Greater_Than_Number2_Then_IsStrictlyGreaterThan_Should_Return_True(
             double doubleNumber1, double doubleNumber2)
         {
-            // arrange
-            var factory = new ConvolutionFactory();
+            // Arrange
+            var number1 = _calculator.CreateConstant(doubleNumber1);
+            var number2 = _calculator.CreateConstant(doubleNumber2);
 
-            var calculator = factory.AlgebraicNumberCalculator;
-
-            var number1 = calculator.CreateConstant(doubleNumber1);
-            var number2 = calculator.CreateConstant(doubleNumber2);
-
-            // act
+            // Act
             var comparison =
-                calculator.IsStrictlyGreaterThan(number1, number2);
+                _calculator.IsStrictlyGreaterThan(number1, number2);
 
-            // assert
+            // Assert
             comparison.Should().BeTrue();
         }
 
@@ -125,18 +112,14 @@ namespace Hilke.KineticConvolution.Tests
         public void When_Number1_Is_Smaller_Than_Number2_Then_IsStrictlyGreaterThan_Should_Return_False(
             double doubleNumber1, double doubleNumber2)
         {
-            // arrange
-            var factory = new ConvolutionFactory();
+            // Arrange
+            var number1 = _calculator.CreateConstant(doubleNumber1);
+            var number2 = _calculator.CreateConstant(doubleNumber2);
 
-            var calculator = factory.AlgebraicNumberCalculator;
+            // Act
+            var comparison = _calculator.IsStrictlyGreaterThan(number1, number2);
 
-            var number1 = calculator.CreateConstant(doubleNumber1);
-            var number2 = calculator.CreateConstant(doubleNumber2);
-
-            // act
-            var comparison = calculator.IsStrictlyGreaterThan(number1, number2);
-
-            // assert
+            // Assert
             comparison.Should().BeFalse();
         }
 
@@ -146,19 +129,15 @@ namespace Hilke.KineticConvolution.Tests
         public void When_Number1_Is_Strictly_Smaller_Than_Number2_Then_IsStrictlySmallerThan_Should_Return_True(
             double doubleNumber1, double doubleNumber2)
         {
-            // arrange
-            var factory = new ConvolutionFactory();
+            // Arrange
+            var number1 = _calculator.CreateConstant(doubleNumber1);
+            var number2 = _calculator.CreateConstant(doubleNumber2);
 
-            var calculator = factory.AlgebraicNumberCalculator;
-
-            var number1 = calculator.CreateConstant(doubleNumber1);
-            var number2 = calculator.CreateConstant(doubleNumber2);
-
-            // act
+            // Act
             var comparison =
-                calculator.IsStrictlySmallerThan(number1, number2);
+                _calculator.IsStrictlySmallerThan(number1, number2);
 
-            // assert
+            // Assert
             comparison.Should().BeTrue();
         }
 
@@ -168,18 +147,14 @@ namespace Hilke.KineticConvolution.Tests
         public void When_Number1_Is_Greater_Than_Number2_Then_IsStrictlySmallerThan_Should_Return_False(
             double doubleNumber1, double doubleNumber2)
         {
-            // arrange
-            var factory = new ConvolutionFactory();
+            // Arrange
+            var number1 = _calculator.CreateConstant(doubleNumber1);
+            var number2 = _calculator.CreateConstant(doubleNumber2);
 
-            var calculator = factory.AlgebraicNumberCalculator;
+            // Act
+            var comparison = _calculator.IsStrictlySmallerThan(number1, number2);
 
-            var number1 = calculator.CreateConstant(doubleNumber1);
-            var number2 = calculator.CreateConstant(doubleNumber2);
-
-            // act
-            var comparison = calculator.IsStrictlySmallerThan(number1, number2);
-
-            // assert
+            // Assert
             comparison.Should().BeFalse();
         }
 
@@ -187,19 +162,15 @@ namespace Hilke.KineticConvolution.Tests
         [TestCase(0.0, 0.0)]
         [TestCase(-0.0, 0.0)]
         [TestCase(1.0, 1.0)]
-        public void When_(double doubleNumber, double expectedAbsoluteValue)
+        public void Number_Absolute_Value_Should_Have_Expected_Value(double doubleNumber, double expectedAbsoluteValue)
         {
-            // arrange
-            var factory = new ConvolutionFactory();
+            // Arrange
+            var number = _calculator.CreateConstant(doubleNumber);
 
-            var calculator = factory.AlgebraicNumberCalculator;
+            // Act
+            var absoluteValue = _calculator.Abs(number);
 
-            var number = calculator.CreateConstant(doubleNumber);
-
-            // act
-            var absoluteValue = calculator.Abs(number);
-
-            // assert
+            // Assert
             absoluteValue.Should().Be(expectedAbsoluteValue);
         }
 
@@ -211,18 +182,14 @@ namespace Hilke.KineticConvolution.Tests
         public void When_Numbers_Are_Equal_Then_AreEqual_Should_Return_Expected_Result(
             double doubleNumber1, double doubleNumber2, bool number1EqualsNumber2Expectation)
         {
-            // arrange
-            var factory = new ConvolutionFactory();
+            // Arrange
+            var number1 = _calculator.CreateConstant(doubleNumber1);
+            var number2 = _calculator.CreateConstant(doubleNumber2);
 
-            var calculator = factory.AlgebraicNumberCalculator;
+            // Act
+            var number1EqualsNumber2 = _calculator.AreEqual(number1, number2);
 
-            var number1 = calculator.CreateConstant(doubleNumber1);
-            var number2 = calculator.CreateConstant(doubleNumber2);
-
-            // act
-            var number1EqualsNumber2 = calculator.AreEqual(number1, number2);
-
-            // assert
+            // Assert
             number1EqualsNumber2.Should().Be(number1EqualsNumber2Expectation);
         }
 
@@ -237,19 +204,15 @@ namespace Hilke.KineticConvolution.Tests
             double doubleTolerance,
             bool numberAreCloseExpectation)
         {
-            // arrange
-            var factory = new ConvolutionFactory();
+            // Arrange
+            var number1 = _calculator.CreateConstant(doubleNumber1);
+            var number2 = _calculator.CreateConstant(doubleNumber2);
+            var tolerance = _calculator.CreateConstant(doubleTolerance);
 
-            var calculator = factory.AlgebraicNumberCalculator;
+            // Act
+            var number1IsCloseToNumber2 = _calculator.AreClose(number1, number2, tolerance);
 
-            var number1 = calculator.CreateConstant(doubleNumber1);
-            var number2 = calculator.CreateConstant(doubleNumber2);
-            var tolerance = calculator.CreateConstant(doubleTolerance);
-
-            // act
-            var number1IsCloseToNumber2 = calculator.AreClose(number1, number2, tolerance);
-
-            // assert
+            // Assert
             number1IsCloseToNumber2.Should().Be(numberAreCloseExpectation);
         }
     }

--- a/tests/Hilke.KineticConvolution.Tests/AlgebraicNumberCalculatorExtensionsTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/AlgebraicNumberCalculatorExtensionsTests.cs
@@ -1,0 +1,256 @@
+using System.Linq;
+
+using FluentAssertions;
+
+using Hilke.KineticConvolution.DoubleAlgebraicNumber;
+
+using NUnit.Framework;
+
+namespace Hilke.KineticConvolution.Tests
+{
+    [TestFixture]
+    public class AlgebraicNumberCalculatorTests
+    {
+        [TestCase(0.0, 0.0)]
+        [TestCase(0.0, 1.0)]
+        [TestCase(-1.0, 0.0)]
+        [TestCase(-3.2, 1.1)]
+        public void When_Number1_Is_Smaller_Than_Number2_Then_IsSmallerThan_Should_Return_True(
+            double doubleNumber1, double doubleNumber2)
+        {
+            // arrange
+            var factory = new ConvolutionFactory();
+
+            var calculator = factory.AlgebraicNumberCalculator;
+
+            var number1 = calculator.CreateConstant(doubleNumber1);
+            var number2 = calculator.CreateConstant(doubleNumber2);
+
+            // act
+            var comparison =
+                calculator.IsSmallerThan(number1, number2);
+
+            // assert
+            comparison.Should().BeTrue();
+        }
+
+        [TestCase(1.0, 0.0)]
+        [TestCase(1.0, -2.0)]
+        public void When_Number1_Is_Strictly_Greater_Than_Number2_Then_IsSmallerThan_Should_Return_False(
+            double doubleNumber1, double doubleNumber2)
+        {
+            // arrange
+            var factory = new ConvolutionFactory();
+
+            var calculator = factory.AlgebraicNumberCalculator;
+
+            var number1 = calculator.CreateConstant(doubleNumber1);
+            var number2 = calculator.CreateConstant(doubleNumber2);
+
+            // act
+            var comparison = calculator.IsSmallerThan(number1, number2);
+
+            // assert
+            comparison.Should().BeFalse();
+        }
+
+        [TestCase(0.0, 0.0)]
+        [TestCase(1.0, 0.0)]
+        [TestCase(0.0, -1.0)]
+        [TestCase(1.1, -3.2)]
+        public void When_Number1_Is_Greater_Than_Number2_Then_IsGreaterThan_Should_Return_True(
+            double doubleNumber1, double doubleNumber2)
+        {
+            // arrange
+            var factory = new ConvolutionFactory();
+
+            var calculator = factory.AlgebraicNumberCalculator;
+
+            var number1 = calculator.CreateConstant(doubleNumber1);
+            var number2 = calculator.CreateConstant(doubleNumber2);
+
+            // act
+            var comparison =
+                calculator.IsGreaterThan(number1, number2);
+
+            // assert
+            comparison.Should().BeTrue();
+        }
+
+        [TestCase(0.0, 1.0)]
+        [TestCase(-2.0, 1.0)]
+        public void When_Number1_Is_Strictly_Smaller_Than_Number2_Then_IsGreaterThan_Should_Return_False(
+            double doubleNumber1, double doubleNumber2)
+        {
+            // arrange
+            var factory = new ConvolutionFactory();
+
+            var calculator = factory.AlgebraicNumberCalculator;
+
+            var number1 = calculator.CreateConstant(doubleNumber1);
+            var number2 = calculator.CreateConstant(doubleNumber2);
+
+            // act
+            var comparison = calculator.IsGreaterThan(number1, number2);
+
+            // assert
+            comparison.Should().BeFalse();
+        }
+
+        [TestCase(1.0, 0.0)]
+        [TestCase(0.0, -1.0)]
+        [TestCase(1.1, -3.2)]
+        public void When_Number1_Is_Strictly_Greater_Than_Number2_Then_IsStrictlyGreaterThan_Should_Return_True(
+            double doubleNumber1, double doubleNumber2)
+        {
+            // arrange
+            var factory = new ConvolutionFactory();
+
+            var calculator = factory.AlgebraicNumberCalculator;
+
+            var number1 = calculator.CreateConstant(doubleNumber1);
+            var number2 = calculator.CreateConstant(doubleNumber2);
+
+            // act
+            var comparison =
+                calculator.IsStrictlyGreaterThan(number1, number2);
+
+            // assert
+            comparison.Should().BeTrue();
+        }
+
+        [TestCase(0.0, 0.0)]
+        [TestCase(0.0, 1.0)]
+        [TestCase(-2.0, 1.0)]
+        public void When_Number1_Is_Smaller_Than_Number2_Then_IsStrictlyGreaterThan_Should_Return_False(
+            double doubleNumber1, double doubleNumber2)
+        {
+            // arrange
+            var factory = new ConvolutionFactory();
+
+            var calculator = factory.AlgebraicNumberCalculator;
+
+            var number1 = calculator.CreateConstant(doubleNumber1);
+            var number2 = calculator.CreateConstant(doubleNumber2);
+
+            // act
+            var comparison = calculator.IsStrictlyGreaterThan(number1, number2);
+
+            // assert
+            comparison.Should().BeFalse();
+        }
+
+        [TestCase(0.0, 1.0)]
+        [TestCase(-1.0, 0.0)]
+        [TestCase(-3.2, 1.1)]
+        public void When_Number1_Is_Strictly_Smaller_Than_Number2_Then_IsStrictlySmallerThan_Should_Return_True(
+            double doubleNumber1, double doubleNumber2)
+        {
+            // arrange
+            var factory = new ConvolutionFactory();
+
+            var calculator = factory.AlgebraicNumberCalculator;
+
+            var number1 = calculator.CreateConstant(doubleNumber1);
+            var number2 = calculator.CreateConstant(doubleNumber2);
+
+            // act
+            var comparison =
+                calculator.IsStrictlySmallerThan(number1, number2);
+
+            // assert
+            comparison.Should().BeTrue();
+        }
+
+        [TestCase(0.0, 0.0)]
+        [TestCase(1.0, 0.0)]
+        [TestCase(1.0, -2.0)]
+        public void When_Number1_Is_Greater_Than_Number2_Then_IsStrictlySmallerThan_Should_Return_False(
+            double doubleNumber1, double doubleNumber2)
+        {
+            // arrange
+            var factory = new ConvolutionFactory();
+
+            var calculator = factory.AlgebraicNumberCalculator;
+
+            var number1 = calculator.CreateConstant(doubleNumber1);
+            var number2 = calculator.CreateConstant(doubleNumber2);
+
+            // act
+            var comparison = calculator.IsStrictlySmallerThan(number1, number2);
+
+            // assert
+            comparison.Should().BeFalse();
+        }
+
+        [TestCase(-1.0, 1.0)]
+        [TestCase(0.0, 0.0)]
+        [TestCase(-0.0, 0.0)]
+        [TestCase(1.0, 1.0)]
+        public void When_(double doubleNumber, double expectedAbsoluteValue)
+        {
+            // arrange
+            var factory = new ConvolutionFactory();
+
+            var calculator = factory.AlgebraicNumberCalculator;
+
+            var number = calculator.CreateConstant(doubleNumber);
+
+            // act
+            var absoluteValue = calculator.Abs(number);
+
+            // assert
+            absoluteValue.Should().Be(expectedAbsoluteValue);
+        }
+
+        [TestCase(0.0, 0.0, true)]
+        [TestCase(3.0, 0.0, false)]
+        [TestCase(0.0, 4.0, false)]
+        [TestCase(-2.0, -2.0, true)]
+        [TestCase(2.0, 2.0, true)]
+        public void When_Numbers_Are_Equal_Then_AreEqual_Should_Return_Expected_Result(
+            double doubleNumber1, double doubleNumber2, bool number1EqualsNumber2Expectation)
+        {
+            // arrange
+            var factory = new ConvolutionFactory();
+
+            var calculator = factory.AlgebraicNumberCalculator;
+
+            var number1 = calculator.CreateConstant(doubleNumber1);
+            var number2 = calculator.CreateConstant(doubleNumber2);
+
+            // act
+            var number1EqualsNumber2 = calculator.AreEqual(number1, number2);
+
+            // assert
+            number1EqualsNumber2.Should().Be(number1EqualsNumber2Expectation);
+        }
+
+        [TestCase(0.0, 0.0, 0.0, true)]
+        [TestCase(1.0, 1.05, 0.1, true)]
+        [TestCase(1.0, 0.95, 0.1, true)]
+        [TestCase(1.0, 1.15, 0.1, false)]
+        [TestCase(1.0, 0.85, 0.1, false)]
+        public void When_Numbers_Are_Close_Then_AreClose_Should_Return_True(
+            double doubleNumber1,
+            double doubleNumber2,
+            double doubleTolerance,
+            bool numberAreCloseExpectation)
+        {
+            // arrange
+            var factory = new ConvolutionFactory();
+
+            var calculator = factory.AlgebraicNumberCalculator;
+
+            var number1 = calculator.CreateConstant(doubleNumber1);
+            var number2 = calculator.CreateConstant(doubleNumber2);
+            var tolerance = calculator.CreateConstant(doubleTolerance);
+
+            // act
+            var number1IsCloseToNumber2 = calculator.AreClose(number1, number2, tolerance);
+
+            // assert
+            number1IsCloseToNumber2.Should().Be(numberAreCloseExpectation);
+        }
+    }
+}


### PR DESCRIPTION
The comparison of `TAlgebraicNumber` in the implementation of `Point.Equals` did not use the mathematical definition to test the X,Y components for equality, which should have been equivalent to `(X1 - X2).Sign() == 0`. This PR fixes this.

Useful extensions methods on the `IAlgebraicNumberCalculator` are also implemented: `IsSmallerThan`, `IsStrictlySmallerThan`, `IsGreaterThan`, `IsStrictlyGreaterThan`, `Abs`, `AreEqual`, `AreClose`.

Question: Should I also implement `BelongsToInterval`/`StrictlyBelongsToInterval`?