### PR TITLE
Allow to create a non G1 continuous shape

### DIFF
--- a/src/Hilke.KineticConvolution/ConvolutionFactory.cs
+++ b/src/Hilke.KineticConvolution/ConvolutionFactory.cs
@@ -140,6 +140,16 @@ namespace Hilke.KineticConvolution
             Shape<TAlgebraicNumber> shape1,
             Shape<TAlgebraicNumber> shape2)
         {
+            if (!shape1.IsG1Continuous())
+            {
+                throw new ArgumentException("Both shapes must be G1 continuous. Shape 1 was not continuous.", nameof(shape1));
+            }
+
+            if (!shape2.IsG1Continuous())
+            {
+                throw new ArgumentException("Both shapes must be G1 continuous. Shape 2 was not continuous.", nameof(shape2));
+            }
+
             var convolutions =
                 from tracing1 in shape1.Tracings
                 from tracing2 in shape2.Tracings

--- a/src/Hilke.KineticConvolution/ConvolutionFactory.cs
+++ b/src/Hilke.KineticConvolution/ConvolutionFactory.cs
@@ -157,20 +157,7 @@ namespace Hilke.KineticConvolution
                 throw new ArgumentException("There should be at least one tracing.", nameof(tracings));
             }
 
-            if (!isG1Continuous(tracingsEnumerated))
-            {
-                throw new ArgumentException("The tracings should be continuous.", nameof(tracings));
-            }
-
             return new Shape<TAlgebraicNumber>(tracingsEnumerated);
-
-            static bool isG1Continuous(IReadOnlyList<Tracing<TAlgebraicNumber>> tracings)
-            {
-                return tracings.Zip(
-                                   tracings.Skip(1).Concat(new[] {tracings.First()}),
-                                   (right, left) => right.IsG1ContinuousWith(left))
-                               .All(isContinuous => isContinuous);
-            }
         }
 
         internal IEnumerable<ConvolvedTracing<TAlgebraicNumber>> Convolve(

--- a/src/Hilke.KineticConvolution/Shape.cs
+++ b/src/Hilke.KineticConvolution/Shape.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace Hilke.KineticConvolution
 {
@@ -8,5 +8,12 @@ namespace Hilke.KineticConvolution
         internal Shape(IReadOnlyList<Tracing<TAlgebraicNumber>> tracings) => Tracings = tracings;
 
         public IReadOnlyList<Tracing<TAlgebraicNumber>> Tracings { get; }
+
+        public bool IsG1Continuous() =>
+            Tracings
+                .Zip(
+                    Tracings.Skip(1).Concat(new[] {Tracings.First()}),
+                    (right, left) => right.IsG1ContinuousWith(left))
+                .All(isContinuous => isContinuous);
     }
 }


### PR DESCRIPTION
There was a test in the creation of the `Shape` to disallow the creation of a Shape that is not G1 continuous. This blocked the use of the `Shape` object for other use case.

This change allows to create non G1 continuous shapes but keeps that check when it is needed in the algorithms.