### PR TITLE
Small fixes and improvements towards version 1.0.0

### DIFF
--- a/src/Hilke.KineticConvolution/Arc.cs
+++ b/src/Hilke.KineticConvolution/Arc.cs
@@ -10,15 +10,15 @@ namespace Hilke.KineticConvolution
     {
         internal Arc(
             IAlgebraicNumberCalculator<TAlgebraicNumber> calculator,
-            Fraction weight,
             Point<TAlgebraicNumber> center,
             DirectionRange<TAlgebraicNumber> directions,
             TAlgebraicNumber radius,
             Point<TAlgebraicNumber> start,
             Point<TAlgebraicNumber> end,
-            Direction<TAlgebraicNumber> startDirection,
-            Direction<TAlgebraicNumber> endDirection)
-            : base(calculator, start, end, startDirection, endDirection, weight)
+            Direction<TAlgebraicNumber> startTangentDirection,
+            Direction<TAlgebraicNumber> endTangentDirection,
+            Fraction weight)
+            : base(calculator, start, end, startTangentDirection, endTangentDirection, weight)
         {
             Center = center ?? throw new ArgumentNullException(nameof(center));
             Directions = directions ?? throw new ArgumentNullException(nameof(directions));

--- a/src/Hilke.KineticConvolution/ConvolutionFactory.cs
+++ b/src/Hilke.KineticConvolution/ConvolutionFactory.cs
@@ -243,11 +243,13 @@ namespace Hilke.KineticConvolution
                         + $"but got {arc.Directions.Orientation}.")
                 };
 
-            var isSegmentConvolvedWithArcExtremity =
-                segmentNormalDirection == arc.Directions.Start ||
-                segmentNormalDirection == arc.Directions.End;
+            var segmentNormalDirectionIsStart = segmentNormalDirection == arc.Directions.Start;
+            var segmentNormalDirectionIsEnd = segmentNormalDirection == arc.Directions.End;
 
-            var convolutionWeight = isSegmentConvolvedWithArcExtremity
+            var isSegmentConvolvedWithOneArcExtremity =
+                segmentNormalDirectionIsStart ^ segmentNormalDirectionIsEnd;
+
+            var convolutionWeight = isSegmentConvolvedWithOneArcExtremity
                 ? new Fraction(1, 2) * arc.Weight * segment.Weight
                 : arc.Weight * segment.Weight;
 

--- a/src/Hilke.KineticConvolution/ConvolutionFactory.cs
+++ b/src/Hilke.KineticConvolution/ConvolutionFactory.cs
@@ -107,14 +107,14 @@ namespace Hilke.KineticConvolution
 
             return new Arc<TAlgebraicNumber>(
                 AlgebraicNumberCalculator,
-                weight,
                 center,
                 directions,
                 radius,
                 start,
                 end,
                 startDirection,
-                endDirection);
+                endDirection,
+                weight);
         }
 
         public Arc<TAlgebraicNumber> CreateArc(

--- a/src/Hilke.KineticConvolution/ConvolutionFactory.cs
+++ b/src/Hilke.KineticConvolution/ConvolutionFactory.cs
@@ -254,7 +254,7 @@ namespace Hilke.KineticConvolution
                 ? new Fraction(1, 2) * arc.Weight * segment.Weight
                 : arc.Weight * segment.Weight;
 
-            if (segment.NormalDirection.Opposite().BelongsTo(arc.Directions))
+            if (segmentNormalDirection.BelongsTo(arc.Directions))
             {
                 return new[]
                 {

--- a/src/Hilke.KineticConvolution/ConvolutionFactory.cs
+++ b/src/Hilke.KineticConvolution/ConvolutionFactory.cs
@@ -222,14 +222,11 @@ namespace Hilke.KineticConvolution
                         AlgebraicNumberCalculator.IsStrictlyNegative(signedRadius)
                             ? range.Opposite()
                             : range,
-                        Abs(signedRadius),
+                        AlgebraicNumberCalculator.Abs(signedRadius),
                         arc1.Weight * arc2.Weight);
                 })
                 .Select(arc => new ConvolvedTracing<TAlgebraicNumber>(arc, arc1, arc2));
         }
-
-        private TAlgebraicNumber Abs(TAlgebraicNumber value) =>
-            AlgebraicNumberCalculator.IsStrictlyNegative(value) ? AlgebraicNumberCalculator.Opposite(value) : value;
 
         internal IEnumerable<Tracing<TAlgebraicNumber>> ConvolveArcAndSegment(
             Arc<TAlgebraicNumber> arc,

--- a/src/Hilke.KineticConvolution/ConvolutionFactory.cs
+++ b/src/Hilke.KineticConvolution/ConvolutionFactory.cs
@@ -96,14 +96,14 @@ namespace Hilke.KineticConvolution
             var end = center.Translate(directions.End, radius);
 
             var startNormalDirection = directions.Start.NormalDirection();
-            var startDirection = directions.Orientation == Orientation.Clockwise
-                                     ? startNormalDirection.Opposite()
-                                     : startNormalDirection;
+            var startTangentDirection = directions.Orientation == Orientation.Clockwise
+                ? startNormalDirection.Opposite()
+                : startNormalDirection;
 
             var endNormalDirection = directions.End.NormalDirection();
-            var endDirection = directions.Orientation == Orientation.Clockwise
-                                   ? endNormalDirection.Opposite()
-                                   : endNormalDirection;
+            var endTangentDirection = directions.Orientation == Orientation.Clockwise
+                ? endNormalDirection.Opposite()
+                : endNormalDirection;
 
             return new Arc<TAlgebraicNumber>(
                 AlgebraicNumberCalculator,
@@ -112,8 +112,8 @@ namespace Hilke.KineticConvolution
                 radius,
                 start,
                 end,
-                startDirection,
-                endDirection,
+                startTangentDirection,
+                endTangentDirection,
                 weight);
         }
 

--- a/src/Hilke.KineticConvolution/ConvolvedTracing.cs
+++ b/src/Hilke.KineticConvolution/ConvolvedTracing.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 
 namespace Hilke.KineticConvolution
 {
-    [DebuggerDisplay("Convolution(Convolution: {Convolution}, Parent1: {Parent1}, Parent2: {Parent2})")]
+    [DebuggerDisplay("ConvolvedTracing(Convolution: {Convolution}, Parent1: {Parent1}, Parent2: {Parent2})")]
     public sealed class ConvolvedTracing<TAlgebraicNumber>
     {
         public ConvolvedTracing(

--- a/src/Hilke.KineticConvolution/Direction.cs
+++ b/src/Hilke.KineticConvolution/Direction.cs
@@ -65,9 +65,29 @@ namespace Hilke.KineticConvolution
 
         public DirectionOrder CompareTo(Direction<TAlgebraicNumber> direction1, Direction<TAlgebraicNumber> direction2)
         {
+            if (direction1 is null)
+            {
+                throw new ArgumentNullException(nameof(direction1));
+            }
+
+            if (direction2 is null)
+            {
+                throw new ArgumentNullException(nameof(direction2));
+            }
+
             if (direction1.Equals(direction2))
             {
                 return DirectionOrder.Equal;
+            }
+
+            if (Equals(direction1))
+            {
+                return DirectionOrder.Before;
+            }
+
+            if (Equals(direction2))
+            {
+                return DirectionOrder.After;
             }
 
             return direction1.BelongsTo(
@@ -76,8 +96,8 @@ namespace Hilke.KineticConvolution
                            this,
                            direction2,
                            Orientation.CounterClockwise))
-                       ? DirectionOrder.After
-                       : DirectionOrder.Before;
+                       ? DirectionOrder.Before
+                       : DirectionOrder.After;
         }
 
         public Direction<TAlgebraicNumber> FirstOf(
@@ -85,8 +105,8 @@ namespace Hilke.KineticConvolution
             Direction<TAlgebraicNumber> direction2) =>
             CompareTo(direction1, direction2) switch
             {
-                DirectionOrder.Before => direction2,
-                DirectionOrder.After => direction1,
+                DirectionOrder.Before => direction1,
+                DirectionOrder.After => direction2,
                 DirectionOrder.Equal => direction1,
                 var order =>
                     throw new NotSupportedException(
@@ -99,8 +119,8 @@ namespace Hilke.KineticConvolution
             Direction<TAlgebraicNumber> direction2) =>
             CompareTo(direction1, direction2) switch
             {
-                DirectionOrder.Before => direction1,
-                DirectionOrder.After => direction2,
+                DirectionOrder.Before => direction2,
+                DirectionOrder.After => direction1,
                 DirectionOrder.Equal => direction1,
                 var order =>
                     throw new NotSupportedException(

--- a/src/Hilke.KineticConvolution/Direction.cs
+++ b/src/Hilke.KineticConvolution/Direction.cs
@@ -108,7 +108,7 @@ namespace Hilke.KineticConvolution
                       + $"{DirectionOrder.Equal} or {DirectionOrder.After}, but got {(int)order}.")
             };
 
-        public bool BelongsToShortestRange(DirectionRange<TAlgebraicNumber> directions)
+        internal bool BelongsToShortestRange(DirectionRange<TAlgebraicNumber> directions)
         {
             var determinant = directions.Start.Determinant(directions.End);
 

--- a/src/Hilke.KineticConvolution/Direction.cs
+++ b/src/Hilke.KineticConvolution/Direction.cs
@@ -200,8 +200,10 @@ namespace Hilke.KineticConvolution
             if (other is Direction<TAlgebraicNumber> direction)
             {
                 return _calculator.IsZero(Determinant(direction))
-                    && _calculator.Sign(X) == _calculator.Sign(direction.X)
-                    && _calculator.Sign(Y) == _calculator.Sign(direction.Y);
+                    && _calculator.IsStrictlyPositive(
+                        _calculator.Add(
+                            _calculator.Multiply(X, direction.X),
+                            _calculator.Multiply(Y, direction.Y)));
             }
 
             return false;

--- a/src/Hilke.KineticConvolution/Direction.cs
+++ b/src/Hilke.KineticConvolution/Direction.cs
@@ -46,10 +46,8 @@ namespace Hilke.KineticConvolution
         public TAlgebraicNumber Y { get; }
 
         /// <inheritdoc />
-        public bool Equals(Direction<TAlgebraicNumber>? other)
-        {
-            return Equals(other as object);
-        }
+        public bool Equals(Direction<TAlgebraicNumber>? other) =>
+            Equals(other as object);
 
         public TAlgebraicNumber Determinant(Direction<TAlgebraicNumber> other)
         {
@@ -63,38 +61,38 @@ namespace Hilke.KineticConvolution
             return _calculator.Subtract(a, b);
         }
 
-        public DirectionOrder CompareTo(Direction<TAlgebraicNumber> direction1, Direction<TAlgebraicNumber> direction2)
+        public DirectionOrder CompareTo(Direction<TAlgebraicNumber> direction, Direction<TAlgebraicNumber> referenceDirection)
         {
-            if (direction1 is null)
+            if (direction is null)
             {
-                throw new ArgumentNullException(nameof(direction1));
+                throw new ArgumentNullException(nameof(direction));
             }
 
-            if (direction2 is null)
+            if (referenceDirection is null)
             {
-                throw new ArgumentNullException(nameof(direction2));
+                throw new ArgumentNullException(nameof(referenceDirection));
             }
 
-            if (direction1.Equals(direction2))
+            if (Equals(direction))
             {
                 return DirectionOrder.Equal;
             }
 
-            if (Equals(direction1))
-            {
-                return DirectionOrder.Before;
-            }
-
-            if (Equals(direction2))
+            if (referenceDirection.Equals(direction))
             {
                 return DirectionOrder.After;
             }
 
-            return direction1.BelongsTo(
+            if (Equals(referenceDirection))
+            {
+                return DirectionOrder.Before;
+            }
+
+            return BelongsTo(
                        new DirectionRange<TAlgebraicNumber>(
                            _calculator,
-                           this,
-                           direction2,
+                           referenceDirection,
+                           direction,
                            Orientation.CounterClockwise))
                        ? DirectionOrder.Before
                        : DirectionOrder.After;
@@ -103,7 +101,7 @@ namespace Hilke.KineticConvolution
         public Direction<TAlgebraicNumber> FirstOf(
             Direction<TAlgebraicNumber> direction1,
             Direction<TAlgebraicNumber> direction2) =>
-            CompareTo(direction1, direction2) switch
+            direction1.CompareTo(direction2, this) switch
             {
                 DirectionOrder.Before => direction1,
                 DirectionOrder.After => direction2,
@@ -117,7 +115,7 @@ namespace Hilke.KineticConvolution
         public Direction<TAlgebraicNumber> LastOf(
             Direction<TAlgebraicNumber> direction1,
             Direction<TAlgebraicNumber> direction2) =>
-            CompareTo(direction1, direction2) switch
+            direction1.CompareTo(direction2, this) switch
             {
                 DirectionOrder.Before => direction2,
                 DirectionOrder.After => direction1,

--- a/src/Hilke.KineticConvolution/DirectionRange.cs
+++ b/src/Hilke.KineticConvolution/DirectionRange.cs
@@ -18,6 +18,7 @@ namespace Hilke.KineticConvolution
             Orientation orientation)
         {
             _calculator = calculator ?? throw new ArgumentNullException(nameof(calculator));
+
             Start = start ?? throw new ArgumentNullException(nameof(start));
 
             End = end ?? throw new ArgumentNullException(nameof(end));
@@ -39,7 +40,7 @@ namespace Hilke.KineticConvolution
 
         public Orientation Orientation { get; }
 
-        public bool IsShortestRange()
+        internal bool IsShortestRange()
         {
             if (Start == End)
             {

--- a/src/Hilke.KineticConvolution/DirectionRange.cs
+++ b/src/Hilke.KineticConvolution/DirectionRange.cs
@@ -122,8 +122,8 @@ namespace Hilke.KineticConvolution
                     range.Start.FirstOf(End, range.End),
                     Orientation.CounterClockwise);
 
-                if (Start.CompareTo(range.Start, range.End) == DirectionOrder.After
-                 && End.CompareTo(range.End, Start) == DirectionOrder.After)
+                if (range.Start.CompareTo(range.End, Start) == DirectionOrder.After
+                    && range.End.CompareTo(Start, End) == DirectionOrder.After)
                 {
                     yield return new DirectionRange<TAlgebraicNumber>(
                         _calculator,
@@ -132,7 +132,7 @@ namespace Hilke.KineticConvolution
                         Orientation.CounterClockwise);
                 }
             }
-            else if (range.Start.CompareTo(range.End, Start) == DirectionOrder.After)
+            else if (range.End.CompareTo(Start, range.Start) == DirectionOrder.After)
             {
                 yield return new DirectionRange<TAlgebraicNumber>(
                     _calculator,

--- a/src/Hilke.KineticConvolution/DirectionRange.cs
+++ b/src/Hilke.KineticConvolution/DirectionRange.cs
@@ -119,7 +119,7 @@ namespace Hilke.KineticConvolution
                 yield return new DirectionRange<TAlgebraicNumber>(
                     _calculator,
                     range.Start,
-                    Start.FirstOf(End, range.End),
+                    range.Start.FirstOf(End, range.End),
                     Orientation.CounterClockwise);
 
                 if (Start.CompareTo(range.Start, range.End) == DirectionOrder.After

--- a/src/Hilke.KineticConvolution/DirectionRange.cs
+++ b/src/Hilke.KineticConvolution/DirectionRange.cs
@@ -114,19 +114,16 @@ namespace Hilke.KineticConvolution
                 throw new ArgumentException("The direction range must be counterclockwise.", nameof(range));
             }
 
-            if (range.Start.BelongsTo(this))
+            if (range.Start.StrictlyBelongsTo(this))
             {
-                if (range.Start != End)
-                {
-                    yield return new DirectionRange<TAlgebraicNumber>(
-                        _calculator,
-                        range.Start,
-                        Start.FirstOf(End, range.End),
-                        Orientation.CounterClockwise);
-                }
+                yield return new DirectionRange<TAlgebraicNumber>(
+                    _calculator,
+                    range.Start,
+                    Start.FirstOf(End, range.End),
+                    Orientation.CounterClockwise);
 
-                if (Start.CompareTo(range.Start, range.End) == DirectionOrder.Before
-                 && End.CompareTo(range.End, Start) == DirectionOrder.Before)
+                if (Start.CompareTo(range.Start, range.End) == DirectionOrder.After
+                 && End.CompareTo(range.End, Start) == DirectionOrder.After)
                 {
                     yield return new DirectionRange<TAlgebraicNumber>(
                         _calculator,
@@ -135,7 +132,7 @@ namespace Hilke.KineticConvolution
                         Orientation.CounterClockwise);
                 }
             }
-            else if (range.Start.CompareTo(range.End, Start) == DirectionOrder.Before)
+            else if (range.Start.CompareTo(range.End, Start) == DirectionOrder.After)
             {
                 yield return new DirectionRange<TAlgebraicNumber>(
                     _calculator,

--- a/src/Hilke.KineticConvolution/IConvolutionFactory.cs
+++ b/src/Hilke.KineticConvolution/IConvolutionFactory.cs
@@ -1,5 +1,7 @@
 ﻿using Fractions;
 
+using System.Collections.Generic;
+
 namespace Hilke.KineticConvolution
 {
     public interface IConvolutionFactory<TAlgebraicNumber>
@@ -51,5 +53,8 @@ namespace Hilke.KineticConvolution
         Convolution<TAlgebraicNumber> ConvolveShapes(
             Shape<TAlgebraicNumber> shape1,
             Shape<TAlgebraicNumber> shape2);
+
+        Shape<TAlgebraicNumber> CreateShape(
+            IEnumerable<Tracing<TAlgebraicNumber>> tracings);
     }
 }

--- a/src/Hilke.KineticConvolution/IConvolutionFactory.cs
+++ b/src/Hilke.KineticConvolution/IConvolutionFactory.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Fractions;
+﻿using Fractions;
 
 namespace Hilke.KineticConvolution
 {

--- a/src/Hilke.KineticConvolution/Segment.cs
+++ b/src/Hilke.KineticConvolution/Segment.cs
@@ -4,7 +4,7 @@ using Fractions;
 
 namespace Hilke.KineticConvolution
 {
-    [DebuggerDisplay("Segment(Start: {Start}, End: {End}, Direction: {StartDirection}, Weight: {Weight})")]
+    [DebuggerDisplay("Segment(Start: {Start}, End: {End}, Direction: {Direction}, Weight: {Weight})")]
     public sealed class Segment<TAlgebraicNumber> : Tracing<TAlgebraicNumber>
     {
         internal Segment(

--- a/src/Hilke.KineticConvolution/Segment.cs
+++ b/src/Hilke.KineticConvolution/Segment.cs
@@ -14,21 +14,21 @@ namespace Hilke.KineticConvolution
             Direction<TAlgebraicNumber> startDirection,
             Direction<TAlgebraicNumber> endDirection,
             Fraction weight)
-            : base(calculator, start, end, startDirection, endDirection, weight) { }
-
-        public Direction<TAlgebraicNumber> Direction() =>
-            new Direction<TAlgebraicNumber>(
+            : base(calculator, start, end, startDirection, endDirection, weight)
+        {
+            Direction = new Direction<TAlgebraicNumber>(
                 Calculator,
                 Calculator.Subtract(End.X, Start.X),
                 Calculator.Subtract(End.Y, Start.Y));
 
-        public Direction<TAlgebraicNumber> NormalDirection()
-        {
-            var direction = Direction();
-            return new Direction<TAlgebraicNumber>(
+            NormalDirection = new Direction<TAlgebraicNumber>(
                 Calculator,
-                Calculator.Opposite(direction.Y),
-                direction.X);
+                Calculator.Opposite(Direction.Y),
+                Direction.X);
         }
+
+        public Direction<TAlgebraicNumber> Direction { get; }
+
+        public Direction<TAlgebraicNumber> NormalDirection { get; }
     }
 }

--- a/src/Hilke.KineticConvolution/Segment.cs
+++ b/src/Hilke.KineticConvolution/Segment.cs
@@ -11,23 +11,18 @@ namespace Hilke.KineticConvolution
             IAlgebraicNumberCalculator<TAlgebraicNumber> calculator,
             Point<TAlgebraicNumber> start,
             Point<TAlgebraicNumber> end,
-            Direction<TAlgebraicNumber> startDirection,
-            Direction<TAlgebraicNumber> endDirection,
+            Direction<TAlgebraicNumber> startTangentDirection,
+            Direction<TAlgebraicNumber> endTangentDirection,
             Fraction weight)
-            : base(calculator, start, end, startDirection, endDirection, weight)
+            : base(calculator, start, end, startTangentDirection, endTangentDirection, weight)
         {
-            Direction = new Direction<TAlgebraicNumber>(
-                Calculator,
-                Calculator.Subtract(End.X, Start.X),
-                Calculator.Subtract(End.Y, Start.Y));
-
             NormalDirection = new Direction<TAlgebraicNumber>(
                 Calculator,
-                Calculator.Opposite(Direction.Y),
-                Direction.X);
+                Calculator.Opposite(startTangentDirection.Y),
+                startTangentDirection.X);
         }
 
-        public Direction<TAlgebraicNumber> Direction { get; }
+        public Direction<TAlgebraicNumber> Direction => StartTangentDirection;
 
         public Direction<TAlgebraicNumber> NormalDirection { get; }
     }

--- a/src/Hilke.KineticConvolution/Shape.cs
+++ b/src/Hilke.KineticConvolution/Shape.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Hilke.KineticConvolution
 {

--- a/src/Hilke.KineticConvolution/Tracing.cs
+++ b/src/Hilke.KineticConvolution/Tracing.cs
@@ -10,15 +10,15 @@ namespace Hilke.KineticConvolution
             IAlgebraicNumberCalculator<TAlgebraicNumber> calculator,
             Point<TAlgebraicNumber> start,
             Point<TAlgebraicNumber> end,
-            Direction<TAlgebraicNumber> startDirection,
-            Direction<TAlgebraicNumber> endDirection,
+            Direction<TAlgebraicNumber> startTangentDirection,
+            Direction<TAlgebraicNumber> endTangentDirection,
             Fraction weight)
         {
             Calculator = calculator ?? throw new ArgumentNullException(nameof(start));
             Start = start ?? throw new ArgumentNullException(nameof(start));
             End = end ?? throw new ArgumentNullException(nameof(end));
-            StartDirection = startDirection ?? throw new ArgumentNullException(nameof(startDirection));
-            EndDirection = endDirection ?? throw new ArgumentNullException(nameof(endDirection));
+            StartTangentDirection = startTangentDirection ?? throw new ArgumentNullException(nameof(startTangentDirection));
+            EndTangentDirection = endTangentDirection ?? throw new ArgumentNullException(nameof(endTangentDirection));
             Weight = weight;
         }
 
@@ -28,13 +28,13 @@ namespace Hilke.KineticConvolution
 
         public Point<TAlgebraicNumber> End { get; }
 
-        public Direction<TAlgebraicNumber> StartDirection { get; }
+        public Direction<TAlgebraicNumber> StartTangentDirection { get; }
 
-        public Direction<TAlgebraicNumber> EndDirection { get; }
+        public Direction<TAlgebraicNumber> EndTangentDirection { get; }
 
         protected IAlgebraicNumberCalculator<TAlgebraicNumber> Calculator { get; }
 
         public bool IsG1ContinuousWith(Tracing<TAlgebraicNumber> next) =>
-            End == next.Start && EndDirection == next.StartDirection;
+            End == next.Start && EndTangentDirection == next.StartTangentDirection;
     }
 }

--- a/tests/Hilke.KineticConvolution.Tests/ConvolutionFactoryTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/ConvolutionFactoryTests.cs
@@ -567,5 +567,57 @@ namespace Hilke.KineticConvolution.Tests
                     });
             }
         }
+
+        [Test]
+        public void When_A_Shape_Is_A_Full_Disk_Then_Convolve_Should_Return_Correct_Number_Of_Convolved_Tracings()
+        {
+            // Arrange
+            var eastDirection = _factory.CreateDirection(1.0, 0.0);
+
+            var diskArc = _factory.CreateArc(
+                center: _factory.CreatePoint(0.0, 0.0),
+                directions: _factory.CreateDirectionRange(eastDirection, eastDirection, Orientation.CounterClockwise),
+                radius: 1.0,
+                weight: 1);
+
+            var origin = _factory.CreatePoint(0.0, 0.0);
+
+            var direction = _factory.CreateDirection(1.0, 2.0).NormalDirection().Opposite();
+
+            var smoothingArc1 = _factory.CreateArc(
+                origin,
+                _factory.CreateDirectionRange(
+                    direction.Opposite(),
+                    direction,
+                    Orientation.CounterClockwise),
+                0.0,
+                1);
+
+            var smoothingArc2 = _factory.CreateArc(
+                origin,
+                _factory.CreateDirectionRange(
+                    direction,
+                    direction.Opposite(),
+                    Orientation.CounterClockwise),
+                0.0,
+                1);
+
+            var verticalSegment = _factory.CreateSegment(origin, _factory.CreatePoint(0.0, 1.0), 1);
+
+            // Act
+            var convolution1 = _factory.Convolve(diskArc, smoothingArc1);
+            var convolution2 = _factory.Convolve(diskArc, smoothingArc2);
+            var convolution3 = _factory.Convolve(diskArc, verticalSegment);
+
+            // Assert
+            convolution1.Should().HaveCount(1);
+            convolution2.Should().HaveCount(2);
+            convolution3.Should().HaveCount(1);
+
+            convolution1.Select(convolution => convolution.Convolution).Should().AllBeOfType<Arc<double>>();
+            convolution2.Select(convolution => convolution.Convolution).Should().AllBeOfType<Arc<double>>();
+            convolution3.Single().Convolution.Should().BeOfType(typeof(Segment<double>));
+            convolution3.Single().Convolution.Weight.Should().Be(1);
+        }
     }
 }

--- a/tests/Hilke.KineticConvolution.Tests/ConvolutionFactoryTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/ConvolutionFactoryTests.cs
@@ -85,7 +85,7 @@ namespace Hilke.KineticConvolution.Tests
                 startY: 8,
                 endX: 13,
                 endY: 13,
-                weight: 20);
+                weight: 10);
 
             // Act
             var actual = _factory.ConvolveArcAndSegment(arc, segment);

--- a/tests/Hilke.KineticConvolution.Tests/DirectionTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/DirectionTests.cs
@@ -140,5 +140,21 @@ namespace Hilke.KineticConvolution.Tests
             Direction<double> direction2,
             bool expectedAreEquals) =>
         direction1.Equals(direction2).Should().Be(expectedAreEquals);
+
+        [Test]
+        public void When_Direction1_Is_Before_Direction2_Then_Direction1_Compare_To_direction2_Should_Be_Before()
+        {
+            var reference = _factory.CreateDirection(1.0, 0.0);
+
+            var direction1 = _factory.CreateDirection(-1.0, 0.0);
+            var direction2 = _factory.CreateDirection(1.0, -5.0);
+            var direction3 = _factory.CreateDirection(0.0, 1.0);
+            var direction4 = _factory.CreateDirection(-1.0, 1.0);
+
+            var order1 = reference.CompareTo(direction1, direction2);
+            var order2 = reference.CompareTo(direction3, direction4);
+
+            order2.Should().Be(DirectionOrder.Before);
+        }
     }
 }

--- a/tests/Hilke.KineticConvolution.Tests/DirectionTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/DirectionTests.cs
@@ -135,7 +135,7 @@ namespace Hilke.KineticConvolution.Tests
         }
 
         [TestCaseSource(nameof(DirectionEqualityTestCaseSource))]
-        public void When_test_equality_of_directions(
+        public void When_Directions_Are_Given_Then_Directions_Equality_Should_Be_As_Expected(
             Direction<double> direction1,
             Direction<double> direction2,
             bool expectedAreEquals) =>

--- a/tests/Hilke.KineticConvolution.Tests/DirectionTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/DirectionTests.cs
@@ -12,13 +12,7 @@ namespace Hilke.KineticConvolution.Tests
     [TestFixture]
     public class DirectionTests
     {
-        private static ConvolutionFactory _factory;
-
-        [OneTimeSetUp]
-        public void OneTimeSetUp()
-        {
-            _factory = new ConvolutionFactory();
-        }
+        private static ConvolutionFactory _factory = new ConvolutionFactory();
 
         [Test]
         public void When_Direction_Is_Given_Then_It_Should_Belongs_To_The_Expected_Half_Plan()
@@ -87,19 +81,17 @@ namespace Hilke.KineticConvolution.Tests
 
         private static IEnumerable<TestCaseData> DirectionEqualityTestCaseSource()
         {
-            var factory = new ConvolutionFactory();
-
             yield return new TestCaseData(
-                factory.CreateDirection(1.0, 2.0),
-                factory.CreateDirection(2.0, 4.0),
+                _factory.CreateDirection(1.0, 2.0),
+                _factory.CreateDirection(2.0, 4.0),
                 true).SetName("When_Directions_Only_Change_In_Length_Then_Directions_Should_Be_Equal");
 
-            var equalityTolerance = 1.0e-9;
+            const double equalityTolerance = 1.0e-9;
 
-            var north = factory.CreateDirection(0.0, 1.0);
-            var east = factory.CreateDirection(5.0, 0.0);
-            var south = factory.CreateDirection(0.0, -1.0);
-            var west = factory.CreateDirection(-5.0, 0.0);
+            var north = _factory.CreateDirection(0.0, 1.0);
+            var east = _factory.CreateDirection(5.0, 0.0);
+            var south = _factory.CreateDirection(0.0, -1.0);
+            var west = _factory.CreateDirection(-5.0, 0.0);
 
             var cardinalDirections = new [] {north, east, south, west};
 
@@ -135,10 +127,10 @@ namespace Hilke.KineticConvolution.Tests
 
             IEnumerable<Direction<double>> perturb(Direction<double> direction, double tolerance)
             {
-                yield return factory.CreateDirection(direction.X + tolerance, direction.Y + tolerance);
-                yield return factory.CreateDirection(direction.X - tolerance, direction.Y - tolerance);
-                yield return factory.CreateDirection(direction.X + tolerance, direction.Y - tolerance);
-                yield return factory.CreateDirection(direction.X - tolerance, direction.Y + tolerance);
+                yield return _factory.CreateDirection(direction.X + tolerance, direction.Y + tolerance);
+                yield return _factory.CreateDirection(direction.X - tolerance, direction.Y - tolerance);
+                yield return _factory.CreateDirection(direction.X + tolerance, direction.Y - tolerance);
+                yield return _factory.CreateDirection(direction.X - tolerance, direction.Y + tolerance);
             }
         }
 

--- a/tests/Hilke.KineticConvolution.Tests/DirectionTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/DirectionTests.cs
@@ -141,8 +141,7 @@ namespace Hilke.KineticConvolution.Tests
             bool expectedAreEquals) =>
         direction1.Equals(direction2).Should().Be(expectedAreEquals);
 
-        [Test]
-        public void When_Direction1_Is_Before_Direction2_Then_Direction1_Compare_To_direction2_Should_Be_Before()
+        private static IEnumerable<TestCaseData> _directionComparisonTestCaseSource()
         {
             var reference = _factory.CreateDirection(1.0, 0.0);
 
@@ -151,10 +150,21 @@ namespace Hilke.KineticConvolution.Tests
             var direction3 = _factory.CreateDirection(0.0, 1.0);
             var direction4 = _factory.CreateDirection(-1.0, 1.0);
 
-            var order1 = reference.CompareTo(direction1, direction2);
-            var order2 = reference.CompareTo(direction3, direction4);
-
-            order2.Should().Be(DirectionOrder.Before);
+            yield return new TestCaseData(direction1, direction2, reference, DirectionOrder.Before);
+            yield return new TestCaseData(direction3, direction4, reference, DirectionOrder.Before);
+            yield return new TestCaseData(direction2, direction1, reference, DirectionOrder.After);
+            yield return new TestCaseData(direction4, direction3, reference, DirectionOrder.After);
+            yield return new TestCaseData(direction2, direction2, reference, DirectionOrder.Equal);
+            yield return new TestCaseData(direction1, direction2, direction2, DirectionOrder.After);
+            yield return new TestCaseData(direction1, direction2, direction1, DirectionOrder.Before);
         }
+
+        [TestCaseSource(nameof(_directionComparisonTestCaseSource))]
+        public void When_Directions_Are_Given_Then_CompareTo_Should_Return_Expected_Result(
+            Direction<double> direction1,
+            Direction<double> direction2,
+            Direction<double> reference,
+            DirectionOrder expectedResult) =>
+            direction1.CompareTo(direction2, reference).Should().Be(expectedResult);
     }
 }

--- a/tests/Hilke.KineticConvolution.Tests/DirectionTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/DirectionTests.cs
@@ -4,12 +4,15 @@ using Hilke.KineticConvolution.DoubleAlgebraicNumber;
 
 using NUnit.Framework;
 
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Hilke.KineticConvolution.Tests
 {
     [TestFixture]
     public class DirectionTests
     {
-        private ConvolutionFactory _factory;
+        private static ConvolutionFactory _factory;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
@@ -81,5 +84,69 @@ namespace Hilke.KineticConvolution.Tests
             westBelongsToClockwiseRange.Should().BeTrue();
             westBelongsToCounterClockwiseRange.Should().BeTrue();
         }
+
+        private static IEnumerable<TestCaseData> DirectionEqualityTestCaseSource()
+        {
+            var factory = new ConvolutionFactory();
+
+            yield return new TestCaseData(
+                factory.CreateDirection(1.0, 2.0),
+                factory.CreateDirection(2.0, 4.0),
+                true).SetName("When_Directions_Only_Change_In_Length_Then_Directions_Should_Be_Equal");
+
+            var equalityTolerance = 1.0e-9;
+
+            var north = factory.CreateDirection(0.0, 1.0);
+            var east = factory.CreateDirection(5.0, 0.0);
+            var south = factory.CreateDirection(0.0, -1.0);
+            var west = factory.CreateDirection(-5.0, 0.0);
+
+            var cardinalDirections = new [] {north, east, south, west};
+
+            foreach (var cardinalDirection in cardinalDirections)
+            {
+                yield return new TestCaseData(cardinalDirection, cardinalDirection, true)
+                    .SetName("When_Direction_Is_A_Cardinal_Direction_Then_It_Should_Equals_Itself");
+            }
+
+            foreach (var directions in cardinalDirections
+                .SelectMany(direction =>
+                    perturb(direction, 0.1 * equalityTolerance)
+                    .Select(perturbedDirection => (direction, perturbedDirection))))
+            {
+                yield return new TestCaseData(directions.direction, directions.perturbedDirection, true)
+                    .SetName("When_Directions_Are_Perturbed_Within_Tolerance_Then_They_Should_Equal");
+            }
+
+            foreach (var directions in cardinalDirections
+                .SelectMany(direction =>
+                    perturb(direction, 10000.0 * equalityTolerance)
+                    .Select(perturbedDirection => (direction, perturbedDirection))))
+            {
+                yield return new TestCaseData(directions.direction, directions.perturbedDirection, false)
+                    .SetName("When_Directions_Are_Perturbed_Beyond_Tolerance_Then_They_Should_Not_Equal");
+            }
+
+            yield return new TestCaseData(north, south, false)
+                .SetName("When_Directions_Are_Opposite_Then_Directions_Should_Not_Equal");
+
+            yield return new TestCaseData(west, east, false)
+                .SetName("When_Directions_Are_Opposite_Then_Directions_Should_Not_Equal");
+
+            IEnumerable<Direction<double>> perturb(Direction<double> direction, double tolerance)
+            {
+                yield return factory.CreateDirection(direction.X + tolerance, direction.Y + tolerance);
+                yield return factory.CreateDirection(direction.X - tolerance, direction.Y - tolerance);
+                yield return factory.CreateDirection(direction.X + tolerance, direction.Y - tolerance);
+                yield return factory.CreateDirection(direction.X - tolerance, direction.Y + tolerance);
+            }
+        }
+
+        [TestCaseSource(nameof(DirectionEqualityTestCaseSource))]
+        public void When_test_equality_of_directions(
+            Direction<double> direction1,
+            Direction<double> direction2,
+            bool expectedAreEquals) =>
+        direction1.Equals(direction2).Should().Be(expectedAreEquals);
     }
 }


### PR DESCRIPTION
This is a global pass of small improvements and minor fixes. Namely:

 - Fix the non-uniformity of the parameter order of some internal constructors,
 - Fix the weight calculation when convolving a segment with an arc extremity, and fix associated unit test,
 - Fix non-uniformity of debugger display strings,
 - Move some methods from `public` to `internal`,
 - Rename `StartDirection`, `EndDirection` to `StartTangentDirection`, `EndTangentDirection`,
 - Avoid unnecessary calculations in `Segment` constructor,
 - Unit test the equality of `Direction`.

⚠️ THERE ARE SEVERAL BREAKING CHANGES ⚠️ 