### PR TITLE
The weight of the convolution with a clockwise arc should be negative

### DIFF
--- a/src/Hilke.KineticConvolution/ConvolutionFactory.cs
+++ b/src/Hilke.KineticConvolution/ConvolutionFactory.cs
@@ -223,7 +223,7 @@ namespace Hilke.KineticConvolution
                             ? range.Opposite()
                             : range,
                         AlgebraicNumberCalculator.Abs(signedRadius),
-                        arc1.Weight * arc2.Weight);
+                        -1 * arc1.Weight * arc2.Weight);
                 })
                 .Select(arc => new ConvolvedTracing<TAlgebraicNumber>(arc, arc1, arc2));
         }
@@ -249,9 +249,12 @@ namespace Hilke.KineticConvolution
             var isSegmentConvolvedWithOneArcExtremity =
                 segmentNormalDirectionIsStart ^ segmentNormalDirectionIsEnd;
 
+            var weightSign = arc.Directions.Orientation == Orientation.CounterClockwise
+                ? 1 : -1;
+
             var convolutionWeight = isSegmentConvolvedWithOneArcExtremity
-                ? new Fraction(1, 2) * arc.Weight * segment.Weight
-                : arc.Weight * segment.Weight;
+                ? new Fraction(1, 2) * weightSign * arc.Weight * segment.Weight
+                : weightSign * arc.Weight * segment.Weight;
 
             if (segmentNormalDirection.BelongsTo(arc.Directions))
             {

--- a/tests/Hilke.KineticConvolution.Tests/ConvolutionFactoryTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/ConvolutionFactoryTests.cs
@@ -180,7 +180,7 @@ namespace Hilke.KineticConvolution.Tests
             // Arrange expected
             var expected = _factory.CreateArc(
                 radius: 1,
-                weight: 6,
+                weight: -6,
                 centerX: 6,
                 centerY: 6,
                 directionStartX: -12,
@@ -231,7 +231,7 @@ namespace Hilke.KineticConvolution.Tests
             // Arrange expected
             var expected = _factory.CreateArc(
                 radius: 1.0,
-                weight: 2,
+                weight: -2,
                 centerX: 6.0,
                 centerY: 6.0,
                 directionStartX: 12.0,
@@ -333,7 +333,7 @@ namespace Hilke.KineticConvolution.Tests
             // Arrange expected
             var expected = _factory.CreateArc(
                 radius: 0.0,
-                weight: 10,
+                weight: -10,
                 centerX: 6.0,
                 centerY: 6.0,
                 directionStartX: 12.0,
@@ -798,7 +798,7 @@ namespace Hilke.KineticConvolution.Tests
                 startY: 13.0,
                 endX: 13.0,
                 endY: 8.0,
-                new Fraction(numerator: 1, denominator: 2));
+                new Fraction(numerator: -1, denominator: 2));
 
             // Act
             var actual = _factory.ConvolveArcAndSegment(arc, segment);


### PR DESCRIPTION
The weight of the convolution of a segment with a clockwise arc should be negative. The weight of the convolution of two arcs with opposite orientation should also be negative. The convolution of two clockwise arcs should be positive, however.

This PR fixes the sign of the weight when building the convolutions between segments.