### PR TITLE
16415 fix direction range intersection

### DIFF
--- a/src/Hilke.KineticConvolution/DirectionRange.cs
+++ b/src/Hilke.KineticConvolution/DirectionRange.cs
@@ -40,11 +40,11 @@ namespace Hilke.KineticConvolution
 
         public Orientation Orientation { get; }
 
-        internal bool IsFullDisk() => Start == End;
+        internal bool IsDegenerate() => Start == End;
 
         internal bool IsShortestRange()
         {
-            if (IsFullDisk())
+            if (IsDegenerate())
             {
                 return false;
             }
@@ -113,41 +113,41 @@ namespace Hilke.KineticConvolution
             DirectionRange<TAlgebraicNumber> range1,
             DirectionRange<TAlgebraicNumber> range2)
         {
-            if (range1.IsFullDisk())
+            if (range1.IsDegenerate())
             {
-                return CounterClockwiseRangeIntersectionWithFullDisk(
+                return CounterClockwiseDegenerateRangesIntersection(
                     calculator, range2, range1);
             }
 
-            if (range2.IsFullDisk())
+            if (range2.IsDegenerate())
             {
-               return CounterClockwiseRangeIntersectionWithFullDisk(
+               return CounterClockwiseDegenerateRangesIntersection(
                    calculator, range1, range2);
             }
 
             return CounterClockwiseRegularRangesIntersection(calculator, range1, range2);
         }
 
-        private static IEnumerable<DirectionRange<TAlgebraicNumber>> CounterClockwiseRangeIntersectionWithFullDisk(
+        private static IEnumerable<DirectionRange<TAlgebraicNumber>> CounterClockwiseDegenerateRangesIntersection(
             IAlgebraicNumberCalculator<TAlgebraicNumber> calculator,
             DirectionRange<TAlgebraicNumber> range,
-            DirectionRange<TAlgebraicNumber> disk)
+            DirectionRange<TAlgebraicNumber> degenerateRange)
         {
-            if (!disk.IsFullDisk())
+            if (!degenerateRange.IsDegenerate())
             {
-                throw new InvalidOperationException("A full disk is expected.");
+                throw new InvalidOperationException("A degenerated range is expected.");
             }
 
-            if (disk.Start.StrictlyBelongsTo(range))
+            if (degenerateRange.Start.StrictlyBelongsTo(range))
             {
                 yield return new DirectionRange<TAlgebraicNumber>(
                     calculator,
-                    disk.Start, range.End,
+                    degenerateRange.Start, range.End,
                     Orientation.CounterClockwise);
 
                 yield return new DirectionRange<TAlgebraicNumber>(
                     calculator,
-                    range.Start, disk.Start,
+                    range.Start, degenerateRange.Start,
                     Orientation.CounterClockwise);
             }
             else

--- a/src/Hilke.KineticConvolution/DirectionRange.cs
+++ b/src/Hilke.KineticConvolution/DirectionRange.cs
@@ -134,11 +134,22 @@ namespace Hilke.KineticConvolution
             }
             else if (range.End.CompareTo(Start, range.Start) == DirectionOrder.After)
             {
-                yield return new DirectionRange<TAlgebraicNumber>(
-                    _calculator,
-                    Start,
-                    Start.FirstOf(End, range.End),
-                    Orientation.CounterClockwise);
+                if (Start == End)
+                {
+                    yield return new DirectionRange<TAlgebraicNumber>(
+                        _calculator,
+                        Start,
+                        range.End,
+                        Orientation.CounterClockwise);
+                }
+                else
+                {
+                    yield return new DirectionRange<TAlgebraicNumber>(
+                        _calculator,
+                        Start,
+                        Start.FirstOf(End, range.End),
+                        Orientation.CounterClockwise);
+                }
             }
         }
     }

--- a/tests/Hilke.KineticConvolution.Tests/DirectionRangeTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/DirectionRangeTests.cs
@@ -47,10 +47,18 @@ namespace Hilke.KineticConvolution.Tests
         {
             // Act
             var actual = range1.Intersection(range2).ToList();
+            var actual2 = range2.Intersection(range1).ToList();
 
             // Assert
             actual.Should().HaveCount(expected.Count);
             actual.Should().BeEquivalentTo(expected);
+
+            actual2.Should().HaveCount(expected.Count);
+            if (range1.Orientation == Orientation.CounterClockwise &&
+                range2.Orientation == Orientation.CounterClockwise)
+            {
+                actual2.Should().BeEquivalentTo(expected);
+            }
         }
     }
 }

--- a/tests/Hilke.KineticConvolution.Tests/TestCaseDataSource/DirectionRangeTestCaseDataSource.cs
+++ b/tests/Hilke.KineticConvolution.Tests/TestCaseDataSource/DirectionRangeTestCaseDataSource.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 using Hilke.KineticConvolution.DoubleAlgebraicNumber;
 
@@ -18,6 +19,27 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             yield return Case03();
             yield return Case04();
             yield return Case05();
+            yield return Case06();
+
+            // Enumerate all combinatorial cases where range R = (S, E), range Rp = (Sp, Ep),
+            // RBar = (E, S) is the complement of range R, R and Rp are counter clockwise,
+            // S is not equal to E, and Sp is not equal to Ep.
+            yield return Case_SpInRBar_EpInRBar1();
+            yield return Case_SpInRBar_EpInRBar2();
+            yield return Case_SpInRBar_EpEqualsS();
+            yield return Case_SpInRBar_EpInR();
+            yield return Case_SpInRBar_EpEqualsE();
+            yield return Case_SpEqualsS_EpInR();
+            yield return Case_SpEqualsS_EpEqualsE();
+            yield return Case_SpEqualsS_EpInRBar();
+            yield return Case_SpInR_EpInR();
+            yield return Case_SpInR_EpEqualsE();
+            yield return Case_SpInR_EpInRBar();
+            yield return Case_SpInR_EpEqualsS();
+            yield return Case_SpInR_EpInR2();
+            yield return Case_SpEqualsE_EpInRBar();
+            yield return Case_SpEqualsE_EpEqualsS();
+            yield return Case_SpEqualsE_EpInR();
         }
 
         private static TestCaseData Case01()
@@ -139,6 +161,399 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
 
             return new TestCaseData(range1, range2, expected)
                 .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case05)}");
+        }
+
+        private static TestCaseData Case06()
+        {
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 0.0, y: -3.0),
+                new Direction<double>(Calculator, x: 0.0, y: -3.0),
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 0.0, y: -3.0),
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersection = range2;
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case06)}");
+        }
+
+        private static TestCaseData Case_SpInRBar_EpInRBar1()
+        {
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: -1.0, y: 1.0),
+                new Direction<double>(Calculator, x: -1.0, y: 0.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersections = Enumerable.Empty<DirectionRange<double>>().ToList();
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInRBar_EpInRBar1)}");
+        }
+
+        private static TestCaseData Case_SpInRBar_EpInRBar2()
+        {
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: -1.0, y: 1.0),
+                new Direction<double>(Calculator, x: -0.5, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersection = range1;
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInRBar_EpInRBar2)}");
+        }
+
+        private static TestCaseData Case_SpInRBar_EpEqualsS()
+        {
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: -1.0, y: -1.0),
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersections = Enumerable.Empty<DirectionRange<double>>().ToList();
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInRBar_EpEqualsS)}");
+        }
+
+        private static TestCaseData Case_SpInRBar_EpInR()
+        {
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: -1.0, y: -1.0),
+                new Direction<double>(Calculator, x: 1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersection = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInRBar_EpInR)}");
+        }
+
+        private static TestCaseData Case_SpInRBar_EpEqualsE()
+        {
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: -1.0, y: -1.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersection = range1;
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInRBar_EpEqualsE)}");
+        }
+
+        private static TestCaseData Case_SpEqualsS_EpInR()
+        {
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersection = range2;
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpEqualsS_EpInR)}");
+        }
+
+        private static TestCaseData Case_SpEqualsS_EpEqualsE()
+        {
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersection = range2;
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpEqualsS_EpEqualsE)}");
+        }
+
+        private static TestCaseData Case_SpEqualsS_EpInRBar()
+        {
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: -1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersection = range1;
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpEqualsS_EpInRBar)}");
+        }
+
+        private static TestCaseData Case_SpInR_EpInR()
+        {
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 1.0),
+                new Direction<double>(Calculator, x: 0.5, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersection = range2;
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInR_EpInR)}");
+        }
+
+        private static TestCaseData Case_SpInR_EpEqualsE()
+        {
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 1.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersection = range2;
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInR_EpEqualsE)}");
+        }
+
+        private static TestCaseData Case_SpInR_EpInRBar()
+        {
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 1.0),
+                new Direction<double>(Calculator, x: -1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersection = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 1.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInR_EpInRBar)}");
+        }
+
+        private static TestCaseData Case_SpInR_EpEqualsS()
+        {
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 1.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersection = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 1.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInR_EpEqualsS)}");
+        }
+
+        private static TestCaseData Case_SpInR_EpInR2()
+        {
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 1.0),
+                new Direction<double>(Calculator, x: 1.0, y: 0.5),
+                Orientation.CounterClockwise);
+
+            var expectedIntersection1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 1.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersection2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 1.0, y: 0.5),
+                Orientation.CounterClockwise);
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection1, expectedIntersection2 };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInR_EpInR2)}");
+        }
+
+        private static TestCaseData Case_SpEqualsE_EpInRBar()
+        {
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                new Direction<double>(Calculator, x: -1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersections = new List<DirectionRange<double>>();
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpEqualsE_EpInRBar)}");
+        }
+
+        private static TestCaseData Case_SpEqualsE_EpEqualsS()
+        {
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersections = new List<DirectionRange<double>>();
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpEqualsE_EpEqualsS)}");
+        }
+
+        private static TestCaseData Case_SpEqualsE_EpInR()
+        {
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                new Direction<double>(Calculator, x: 1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersection = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 0.0),
+                new Direction<double>(Calculator, x: 1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpEqualsE_EpInR)}");
         }
     }
 }

--- a/tests/Hilke.KineticConvolution.Tests/TestCaseDataSource/DirectionRangeTestCaseDataSource.cs
+++ b/tests/Hilke.KineticConvolution.Tests/TestCaseDataSource/DirectionRangeTestCaseDataSource.cs
@@ -40,6 +40,18 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             yield return Case_SpEqualsE_EpInRBar();
             yield return Case_SpEqualsE_EpEqualsS();
             yield return Case_SpEqualsE_EpInR();
+
+            // Enumerate all combinatorial cases where range R = (S, S) is a full disk
+            // and Rp = (Sp, Ep), R and Rp are counter clockwise and Sp is not equal to Ep.
+            yield return Case_RDisk_SpEqualsS_EpInR();
+            yield return Case_RDisk_SpInR_EpInR1();
+            yield return Case_RDisk_SpInR_EpEqualsS();
+            yield return Case_RDisk_SpInR_EpInR2();
+
+            // Enumerate all combinatorial cases where range R = (S, S) is a full disk
+            // and Rp = (Sp, Sp) is a full disk.
+            yield return Case_RDiskRpDisk_SEqualsSp();
+            yield return Case_RDiskRpDisk_SpInR();
         }
 
         private static TestCaseData Case01()
@@ -554,6 +566,163 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
 
             return new TestCaseData(range1, range2, expectedIntersections)
                 .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpEqualsE_EpInR)}");
+        }
+
+        private static TestCaseData Case_RDisk_SpEqualsS_EpInR()
+        {
+            var S = new Direction<double>(Calculator, x: 1.0, y: 0.0);
+
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                S, S,
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                S,
+                new Direction<double>(Calculator, x: 1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersection = range2;
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDisk_SpEqualsS_EpInR)}");
+        }
+
+        private static TestCaseData Case_RDisk_SpInR_EpInR1()
+        {
+            var S = new Direction<double>(Calculator, x: 1.0, y: 0.0);
+
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                S, S,
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 1.0),
+                new Direction<double>(Calculator, x: -1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersection = range2;
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDisk_SpInR_EpInR1)}");
+        }
+
+        private static TestCaseData Case_RDisk_SpInR_EpEqualsS()
+        {
+            var S = new Direction<double>(Calculator, x: 1.0, y: 0.0);
+
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                S, S,
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 1.0, y: 1.0),
+                S,
+                Orientation.CounterClockwise);
+
+            var expectedIntersection = range2;
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDisk_SpInR_EpEqualsS)}");
+        }
+
+        private static TestCaseData Case_RDisk_SpInR_EpInR2()
+        {
+            var S = new Direction<double>(Calculator, x: 1.0, y: 0.0);
+
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                S, S,
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                new Direction<double>(Calculator, x: 1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersection1 = new DirectionRange<double>(
+                Calculator,
+                new Direction<double>(Calculator, x: 0.0, y: 1.0),
+                S,
+                Orientation.CounterClockwise);
+
+            var expectedIntersection2 = new DirectionRange<double>(
+                Calculator,
+                S,
+                new Direction<double>(Calculator, x: 1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection1, expectedIntersection2 };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDisk_SpInR_EpInR2)}");
+        }
+
+        private static TestCaseData Case_RDiskRpDisk_SEqualsSp()
+        {
+            var S = new Direction<double>(Calculator, x: 1.0, y: 0.0);
+
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                S, S,
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                S,
+                S,
+                Orientation.CounterClockwise);
+
+            var expectedIntersection = range2;
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDiskRpDisk_SEqualsSp)}");
+        }
+
+        private static TestCaseData Case_RDiskRpDisk_SpInR()
+        {
+            var S = new Direction<double>(Calculator, x: 1.0, y: 0.0);
+
+            var Sp = new Direction<double>(Calculator, x: 0.0, y: 1.0);
+
+            var range1 = new DirectionRange<double>(
+                Calculator,
+                S, S,
+                Orientation.CounterClockwise);
+
+            var range2 = new DirectionRange<double>(
+                Calculator,
+                Sp, Sp,
+                Orientation.CounterClockwise);
+
+            var expectedIntersection1 = new DirectionRange<double>(
+                Calculator,
+                S, Sp,
+                Orientation.CounterClockwise);
+
+            var expectedIntersection2 = new DirectionRange<double>(
+                Calculator,
+                Sp, S,
+                Orientation.CounterClockwise);
+
+            var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection1, expectedIntersection2 };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDiskRpDisk_SpInR)}");
         }
     }
 }

--- a/tests/Hilke.KineticConvolution.Tests/TestCaseDataSource/DirectionRangeTestCaseDataSource.cs
+++ b/tests/Hilke.KineticConvolution.Tests/TestCaseDataSource/DirectionRangeTestCaseDataSource.cs
@@ -41,17 +41,17 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             yield return Case_SpEqualsE_EpEqualsS();
             yield return Case_SpEqualsE_EpInR();
 
-            // Enumerate all combinatorial cases where range R = (S, S) is a full disk
+            // Enumerate all combinatorial cases where range R = (S, S) is degenerate
             // and Rp = (Sp, Ep), R and Rp are counter clockwise and Sp is not equal to Ep.
-            yield return Case_RDisk_SpEqualsS_EpInR();
-            yield return Case_RDisk_SpInR_EpInR1();
-            yield return Case_RDisk_SpInR_EpEqualsS();
-            yield return Case_RDisk_SpInR_EpInR2();
+            yield return Case_RDegenerate_SpEqualsS_EpInR();
+            yield return Case_RDegenerate_SpInR_EpInR1();
+            yield return Case_RDegenerate_SpInR_EpEqualsS();
+            yield return Case_RDegenerate_SpInR_EpInR2();
 
-            // Enumerate all combinatorial cases where range R = (S, S) is a full disk
-            // and Rp = (Sp, Sp) is a full disk.
-            yield return Case_RDiskRpDisk_SEqualsSp();
-            yield return Case_RDiskRpDisk_SpInR();
+            // Enumerate all combinatorial cases where range R = (S, S) is degenerate
+            // and Rp = (Sp, Sp) is degenerate.
+            yield return Case_RDegenerateRpDegenerate_SEqualsSp();
+            yield return Case_RDegenerateRpDegenerate_SpInR();
         }
 
         private static TestCaseData Case01()
@@ -568,7 +568,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
                 .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpEqualsE_EpInR)}");
         }
 
-        private static TestCaseData Case_RDisk_SpEqualsS_EpInR()
+        private static TestCaseData Case_RDegenerate_SpEqualsS_EpInR()
         {
             var S = new Direction<double>(Calculator, x: 1.0, y: 0.0);
 
@@ -588,10 +588,10 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDisk_SpEqualsS_EpInR)}");
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDegenerate_SpEqualsS_EpInR)}");
         }
 
-        private static TestCaseData Case_RDisk_SpInR_EpInR1()
+        private static TestCaseData Case_RDegenerate_SpInR_EpInR1()
         {
             var S = new Direction<double>(Calculator, x: 1.0, y: 0.0);
 
@@ -611,10 +611,10 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDisk_SpInR_EpInR1)}");
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDegenerate_SpInR_EpInR1)}");
         }
 
-        private static TestCaseData Case_RDisk_SpInR_EpEqualsS()
+        private static TestCaseData Case_RDegenerate_SpInR_EpEqualsS()
         {
             var S = new Direction<double>(Calculator, x: 1.0, y: 0.0);
 
@@ -634,10 +634,10 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDisk_SpInR_EpEqualsS)}");
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDegenerate_SpInR_EpEqualsS)}");
         }
 
-        private static TestCaseData Case_RDisk_SpInR_EpInR2()
+        private static TestCaseData Case_RDegenerate_SpInR_EpInR2()
         {
             var S = new Direction<double>(Calculator, x: 1.0, y: 0.0);
 
@@ -667,10 +667,10 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection1, expectedIntersection2 };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDisk_SpInR_EpInR2)}");
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDegenerate_SpInR_EpInR2)}");
         }
 
-        private static TestCaseData Case_RDiskRpDisk_SEqualsSp()
+        private static TestCaseData Case_RDegenerateRpDegenerate_SEqualsSp()
         {
             var S = new Direction<double>(Calculator, x: 1.0, y: 0.0);
 
@@ -690,10 +690,10 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDiskRpDisk_SEqualsSp)}");
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDegenerateRpDegenerate_SEqualsSp)}");
         }
 
-        private static TestCaseData Case_RDiskRpDisk_SpInR()
+        private static TestCaseData Case_RDegenerateRpDegenerate_SpInR()
         {
             var S = new Direction<double>(Calculator, x: 1.0, y: 0.0);
 
@@ -722,7 +722,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection1, expectedIntersection2 };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDiskRpDisk_SpInR)}");
+                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDegenerateRpDegenerate_SpInR)}");
         }
     }
 }


### PR DESCRIPTION
There was some issues when intersecting full disks with full disks, and full disks with strict cones. This PR refactors and fix the computation of these intersection, and adds a comprehensive suite of tests where all combinatorial cases are tested when intersecting two cones, a cone and a disk, and two disks.

Question: I use the word 'disk' to denote the direction range that contains all possible directions of the plane. But it is not really a disk. It is, namely, 'All possible directions in the plane'. Do you have a better name than 'disk' to describe that?

I could use 'Degenerate' (like in `var degenerateDirectionRange = ...`), but it is ambiguous in the sens that it could describe the empty set of directions of the plane (which is not representable in our present system) as well. I would prefer a term that makes it clear that we are talking about all direction, instead of none.