### PR TITLE
Rename Convolve to ConvolveTracing and move to public visibility

### DIFF
--- a/src/Hilke.KineticConvolution/ConvolutionFactory.cs
+++ b/src/Hilke.KineticConvolution/ConvolutionFactory.cs
@@ -143,7 +143,7 @@ namespace Hilke.KineticConvolution
             var convolutions =
                 from tracing1 in shape1.Tracings
                 from tracing2 in shape2.Tracings
-                select Convolve(tracing1, tracing2);
+                select ConvolveTracings(tracing1, tracing2);
 
             return new Convolution<TAlgebraicNumber>(shape1, shape2, convolutions.SelectMany(x => x).ToList());
         }
@@ -173,7 +173,7 @@ namespace Hilke.KineticConvolution
             }
         }
 
-        internal IEnumerable<ConvolvedTracing<TAlgebraicNumber>> Convolve(
+        public IEnumerable<ConvolvedTracing<TAlgebraicNumber>> ConvolveTracings(
             Tracing<TAlgebraicNumber> tracing1,
             Tracing<TAlgebraicNumber> tracing2) =>
             (tracing1, tracing2) switch

--- a/tests/Hilke.KineticConvolution.Tests/ConvolutionFactoryTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/ConvolutionFactoryTests.cs
@@ -424,7 +424,7 @@ namespace Hilke.KineticConvolution.Tests
                 weight: 4);
 
             // Act
-            var actual = _factory.Convolve(segment1, segment2);
+            var actual = _factory.ConvolveTracings(segment1, segment2);
 
             // Assert
             actual.Should().BeEmpty();
@@ -451,7 +451,7 @@ namespace Hilke.KineticConvolution.Tests
                 weight: 4);
 
             // Act
-            var actual = _factory.Convolve(segment1, segment2);
+            var actual = _factory.ConvolveTracings(segment1, segment2);
 
             // Assert
             actual.Should().BeEmpty();
@@ -607,9 +607,9 @@ namespace Hilke.KineticConvolution.Tests
             var verticalSegment = _factory.CreateSegment(origin, _factory.CreatePoint(0.0, 1.0), 1);
 
             // Act
-            var convolution1 = _factory.Convolve(diskArc, smoothingArc1);
-            var convolution2 = _factory.Convolve(diskArc, smoothingArc2);
-            var convolution3 = _factory.Convolve(diskArc, verticalSegment);
+            var convolution1 = _factory.ConvolveTracings(diskArc, smoothingArc1);
+            var convolution2 = _factory.ConvolveTracings(diskArc, smoothingArc2);
+            var convolution3 = _factory.ConvolveTracings(diskArc, verticalSegment);
 
             // Assert
             convolution1.Should().HaveCount(1);

--- a/tests/Hilke.KineticConvolution.Tests/ConvolutionHelperTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/ConvolutionHelperTests.cs
@@ -41,7 +41,7 @@ namespace Hilke.KineticConvolution.Tests
                 radius: radius2,
                 weight: 1);
 
-            var convolution = convolutionFactory.Convolve(arc1, arc2).ToList();
+            var convolution = convolutionFactory.ConvolveTracings(arc1, arc2).ToList();
 
             convolution.Should().HaveCount(1);
 


### PR DESCRIPTION
It is valuable to let the user build the convolution of individual tracings. A typical usage is to infer the points on the boundary of shape A and shape B which resulted in the point on the boundary of the sum of A and B. In case A and B are not convex, only subsets of the convolution of tracings from A and B may appear on the boundary of the sum. Rebuilding the tracing from the two parents allows to identify the subset of the boundary from A and B result in a part of the boundary of A+B.