### PR TITLE
Fix the convolution signs calculation

### DIFF
--- a/src/Hilke.KineticConvolution/ConvolutionFactory.cs
+++ b/src/Hilke.KineticConvolution/ConvolutionFactory.cs
@@ -203,13 +203,16 @@ namespace Hilke.KineticConvolution
         {
             if (arc1.Directions.Orientation == arc2.Directions.Orientation)
             {
+                var convolutionWeightSign = arc1.Directions.Orientation == Orientation.CounterClockwise ? 1 : -1;
+                var convolutionWeight = convolutionWeightSign * arc1.Weight * arc2.Weight;
+
                 return arc1.Directions.Intersection(arc2.Directions)
                            .Select(
                                range => CreateArc(
                                    arc1.Center.Sum(arc2.Center),
                                    range,
                                    AlgebraicNumberCalculator.Add(arc1.Radius, arc2.Radius),
-                                   arc1.Weight * arc2.Weight))
+                                   convolutionWeight))
                            .Select(arc => new ConvolvedTracing<TAlgebraicNumber>(arc, arc1, arc2));
             }
 
@@ -217,13 +220,18 @@ namespace Hilke.KineticConvolution
                 .Select(range =>
                 {
                     var signedRadius = AlgebraicNumberCalculator.Subtract(arc1.Radius, arc2.Radius);
+
+                    var convolutionWeightSign =
+                        (arc1.Directions.Orientation == Orientation.Clockwise && arc2.Directions.Orientation == Orientation.CounterClockwise);
+                    var convolutionWeight = (convolutionWeightSign ? 1 : -1) * arc1.Weight * arc2.Weight;
+
                     return CreateArc(
                         arc1.Center.Sum(arc2.Center),
                         AlgebraicNumberCalculator.IsStrictlyNegative(signedRadius)
                             ? range.Opposite()
                             : range,
                         AlgebraicNumberCalculator.Abs(signedRadius),
-                        -1 * arc1.Weight * arc2.Weight);
+                        convolutionWeight);
                 })
                 .Select(arc => new ConvolvedTracing<TAlgebraicNumber>(arc, arc1, arc2));
         }

--- a/src/Hilke.KineticConvolution/Tracing.cs
+++ b/src/Hilke.KineticConvolution/Tracing.cs
@@ -35,6 +35,6 @@ namespace Hilke.KineticConvolution
         protected IAlgebraicNumberCalculator<TAlgebraicNumber> Calculator { get; }
 
         public bool IsG1ContinuousWith(Tracing<TAlgebraicNumber> next) =>
-            End == next.Start && EndTangentDirection == next.StartTangentDirection;
+            End == next.Start && EndTangentDirection.Normalize() == next.StartTangentDirection.Normalize();
     }
 }

--- a/tests/Hilke.KineticConvolution.Tests/ConvolutionFactoryTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/ConvolutionFactoryTests.cs
@@ -282,7 +282,7 @@ namespace Hilke.KineticConvolution.Tests
             // Arrange expected
             var expected = _factory.CreateArc(
                 radius: 3.0,
-                weight: 2,
+                weight: -2,
                 centerX: 6.0,
                 centerY: 6.0,
                 directionStartX: 12.0,


### PR DESCRIPTION
The weight calculation is wrong in the case of the convolution of two arcs. Moreover, the correct way to determine the weight of the convolution is finally understood and mastered. 

Precisely, the sign of the weight of the convolution of two segments a*b is the difference between the counts of connected components of the intersection between A and (-B + t), where t is a point which belongs either to the left vicinity or the right vicinity of the convolution a*b. 

Basically, when the point t moves from the left of a*b to the right af a*b, either a connected component disappears in the intersection of A and (-B + t), or a connected component of the intersection of A and (-B + t) is split into two. The transition happens when t is exactly on the convolution a*b, when the boundaries of A and (-B + t) are exactly tangent at p_a \in a. Here t = p_a + p_b, where p_a \in a, p_b \in b. 