### PR TITLE
DirectionRange union and related methods

### DIFF
--- a/src/Hilke.KineticConvolution/Extensions/DirectionRangesExtensions.cs
+++ b/src/Hilke.KineticConvolution/Extensions/DirectionRangesExtensions.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Hilke.KineticConvolution.Extensions
+{
+    public static class DirectionRangesExtensions
+    {
+        public static IEnumerable<DirectionRange<double>> Union(
+            this IEnumerable<DirectionRange<double>> ranges)
+        {
+            if (ranges is null)
+            {
+                throw new ArgumentNullException(nameof(ranges));
+            }
+
+            var orderedRanges = ranges.SortCounterClockwise().ToList();
+            if(!orderedRanges.Any())
+            {
+                return Enumerable.Empty<DirectionRange<double>>();
+            }
+
+            var disjointUnions = new Queue<DirectionRange<double>>();
+            var stagingUnion = orderedRanges[0];
+            foreach (var currentRange in orderedRanges)
+            {
+                var unionWithStaging = stagingUnion.Union(currentRange).ToList();
+                if(unionWithStaging.Count == 2)
+                {
+                    disjointUnions.Enqueue(stagingUnion);
+                    stagingUnion = currentRange;
+                }
+                else
+                {
+                    stagingUnion = unionWithStaging.Single();
+                }
+            }
+
+            if (disjointUnions.Peek().Start.BelongsTo(stagingUnion))
+            {
+                // The last stagingUnion still intersect some ranges
+                // at the front of the queue.
+                var lastIntersectingUnion = disjointUnions.Peek();
+                while (disjointUnions.Count > 0)
+                {
+                    if (disjointUnions.Peek().Start.BelongsTo(stagingUnion))
+                    {
+                        lastIntersectingUnion = disjointUnions.Dequeue();
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                stagingUnion = stagingUnion.Union(lastIntersectingUnion).Single();
+            }
+
+            disjointUnions.Enqueue(stagingUnion);
+            return disjointUnions;
+        }
+
+        public static IEnumerable<DirectionRange<TAlgebraicNumber>> SortCounterClockwise<TAlgebraicNumber>(
+            this IEnumerable<DirectionRange<TAlgebraicNumber>> ranges)
+        {
+            if (ranges is null)
+            {
+                throw new ArgumentNullException(nameof(ranges));
+            }
+
+            var enumeratedRanges = ranges.ToList();
+
+            if (enumeratedRanges.Any())
+            {
+                return SortCounterClockwiseWithRespectTo(
+                    ranges: enumeratedRanges,
+                    referenceDirection: enumeratedRanges[0].Start);
+            }
+            else
+            {
+                return Enumerable.Empty<DirectionRange<TAlgebraicNumber>>();
+            }
+        }
+
+        public static IEnumerable<DirectionRange<TAlgebraicNumber>> SortCounterClockwiseWithRespectTo<TAlgebraicNumber>(
+            this IEnumerable<DirectionRange<TAlgebraicNumber>> ranges,
+            Direction<TAlgebraicNumber> referenceDirection)
+        {
+            if (ranges is null)
+            {
+                throw new ArgumentNullException(nameof(ranges));
+            }
+
+            if (referenceDirection is null)
+            {
+                throw new ArgumentNullException(nameof(referenceDirection));
+            }
+
+            var enumeratedRanges = ranges.ToList();
+            if (enumeratedRanges.Any(range => range.Orientation != Orientation.CounterClockwise))
+            {
+                throw new NotSupportedException("Only counterclockwise ranges can be ordered.");
+            }
+
+            enumeratedRanges.Sort((range1, range2) => (int)range1.Start.CompareTo(range2.Start, referenceDirection));
+
+            return enumeratedRanges;
+        }
+    }
+}

--- a/src/Hilke.KineticConvolution/Hilke.KineticConvolution.csproj
+++ b/src/Hilke.KineticConvolution/Hilke.KineticConvolution.csproj
@@ -17,7 +17,6 @@
     <Title>Kinetic convolution</Title>
     <Description>Implementation of the kinetic convolution of polygonal tracings in the Euclidian plane.</Description>
     <Authors>Thomas Hilke</Authors>
-    <Version>1.1.0-local005</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Hilke.KineticConvolution/Hilke.KineticConvolution.csproj
+++ b/src/Hilke.KineticConvolution/Hilke.KineticConvolution.csproj
@@ -17,6 +17,7 @@
     <Title>Kinetic convolution</Title>
     <Description>Implementation of the kinetic convolution of polygonal tracings in the Euclidian plane.</Description>
     <Authors>Thomas Hilke</Authors>
+    <Version>1.1.0-local005</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Hilke.KineticConvolution.Tests/DirectionRangeExtensionsTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/DirectionRangeExtensionsTests.cs
@@ -1,12 +1,13 @@
+using System.Linq;
+using System.Collections.Generic;
+
 using FluentAssertions;
 
 using Hilke.KineticConvolution.DoubleAlgebraicNumber;
+using Hilke.KineticConvolution.Extensions;
+using Hilke.KineticConvolution.Tests.TestCaseDataSource;
 
 using NUnit.Framework;
-
-using System.Collections.Generic;
-
-using Hilke.KineticConvolution.Tests.TestCaseDataSource;
 
 namespace Hilke.KineticConvolution.Tests
 {
@@ -71,6 +72,76 @@ namespace Hilke.KineticConvolution.Tests
             var intersection = leftHalfPlan.Intersection(rightHalfPlan);
 
             intersection.Should().BeEquivalentTo(expectedRange);
+        }
+
+        [TestCaseSource(
+            typeof(DirectionRangeExtensionsUnionTestCaseDataSource),
+            nameof(DirectionRangeExtensionsUnionTestCaseDataSource.TestCases))]
+        public void When_calling_Union_with_valid_ranges_Then_the_correct_result_Should_be_returned(
+            DirectionRange<double> range1,
+            DirectionRange<double> range2,
+            IReadOnlyList<DirectionRange<double>> expected)
+        {
+            // Arrange
+            var expectedReversed = expected.Select(t => t.Reverse());
+
+            // Act
+            var actual1 = range1.Union(range2).ToList();
+            var actual2 = range2.Union(range1).ToList();
+
+            // Assert
+            actual1.Should().HaveCount(expected.Count);
+            actual1.Should().BeEquivalentTo(expected);
+
+            actual2.Should().HaveCount(expected.Count);
+
+            // degenerate range
+            if (expected.Count == 1 && expected[0].Start == expected[0].End)
+            {
+                actual2[0].Start.Should().BeEquivalentTo(actual2[0].End);
+                actual2[0].Orientation.Should().BeEquivalentTo(range2.Orientation);
+            }
+            else
+            {
+                if (range1.Orientation == range2.Orientation)
+                {
+                    actual2.Should().BeEquivalentTo(expected);
+                }
+                else
+                {
+                    actual2.Should().BeEquivalentTo(expectedReversed);
+                }
+            }
+        }
+
+        [TestCaseSource(
+            typeof(DirectionRangeExtensionsUnionTestCaseDataSource),
+            nameof(DirectionRangeExtensionsUnionTestCaseDataSource.TestCasesMultipleUnion))]
+        public void When_calling_Union_on_valid_multiple_ranges_Then_the_correct_result_Should_be_returned(
+            IEnumerable<DirectionRange<double>> ranges,
+            IReadOnlyList<DirectionRange<double>> expected)
+        {
+            // Act
+            var actual = ranges.Union().ToList();
+
+            // Assert
+            actual.Should().HaveCount(expected.Count);
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [TestCaseSource(
+            typeof(DirectionRangeExtensionsUnionTestCaseDataSource),
+            nameof(DirectionRangeExtensionsUnionTestCaseDataSource.TestCasesSortByStart))]
+        public void When_calling_SortByStart_On_multiple_ranges_Should_sort_correctly(
+            IEnumerable<DirectionRange<double>> unsortedRanges,
+            IReadOnlyList<DirectionRange<double>> expected)
+        {
+            // Act
+            var actual = unsortedRanges.SortCounterClockwise();
+
+            // Assert
+            actual.Should().HaveCount(expected.Count);
+            actual.Should().BeEquivalentTo(expected);
         }
     }
 }

--- a/tests/Hilke.KineticConvolution.Tests/DirectionRangeTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/DirectionRangeTests.cs
@@ -26,6 +26,7 @@ namespace Hilke.KineticConvolution.Tests
             var start = new Direction<double>(_calculator, x: 1.0, y: 0.0);
             var end = new Direction<double>(_calculator, x: 0.0, y: 1.0);
 
+            // Act
             var subject = new DirectionRange<double>(_calculator, start, end, Orientation.CounterClockwise);
 
             Action action = () => _ = subject.Intersection(null!);
@@ -37,21 +38,40 @@ namespace Hilke.KineticConvolution.Tests
                   .Be(expected: "other");
         }
 
+        [Test]
+        public void When_calling_Union_with_null_range_Then_an_ArgumentNullException_Should_be_thrown()
+        {
+            // Arrange
+            var start = new Direction<double>(_calculator, x: 1.0, y: 0.0);
+            var end = new Direction<double>(_calculator, x: 1.0, y: 0.0);
+
+            var subject = new DirectionRange<double>(_calculator, start, end, Orientation.CounterClockwise);
+
+            // Act
+            Action action = () => _ = subject.Union(null);
+
+            // Assert
+            action.Should()
+                .ThrowExactly<ArgumentNullException>()
+                .And.ParamName.Should()
+                .Be(expected: "other");
+        }
+
         [TestCaseSource(
-            typeof(DirectionRangeTestCaseDataSource),
-            nameof(DirectionRangeTestCaseDataSource.TestCases))]
+            typeof(DirectionRangeExtensionsIntersectionTestCaseDataSource),
+            nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource.TestCases))]
         public void When_calling_Intersection_with_valid_ranges_Then_the_correct_result_Should_be_returned(
             DirectionRange<double> range1,
             DirectionRange<double> range2,
             IReadOnlyList<DirectionRange<double>> expected)
         {
             // Act
-            var actual = range1.Intersection(range2).ToList();
+            var actual1 = range1.Intersection(range2).ToList();
             var actual2 = range2.Intersection(range1).ToList();
 
             // Assert
-            actual.Should().HaveCount(expected.Count);
-            actual.Should().BeEquivalentTo(expected);
+            actual1.Should().HaveCount(expected.Count);
+            actual1.Should().BeEquivalentTo(expected);
 
             actual2.Should().HaveCount(expected.Count);
             if (range1.Orientation == Orientation.CounterClockwise &&

--- a/tests/Hilke.KineticConvolution.Tests/TestCaseDataSource/DirectionRangeExtensionsIntersectionTestCaseDataSource.cs
+++ b/tests/Hilke.KineticConvolution.Tests/TestCaseDataSource/DirectionRangeExtensionsIntersectionTestCaseDataSource.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 
 namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
 {
-    internal static class DirectionRangeTestCaseDataSource
+    internal static class DirectionRangeExtensionsIntersectionTestCaseDataSource
     {
         private static readonly IAlgebraicNumberCalculator<double> Calculator =
             new DoubleAlgebraicNumberCalculator(zeroTolerance: 1e-12);
@@ -74,7 +74,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expected = new List<DirectionRange<double>> {expectedRange};
 
             return new TestCaseData(range1, range2, expected)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case01)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case01)}");
         }
 
         private static TestCaseData Case02()
@@ -103,7 +103,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expected = new List<DirectionRange<double>> {expectedRange1, expectedRange2};
 
             return new TestCaseData(range1, range2, expected)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case02)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case02)}");
         }
 
         private static TestCaseData Case03()
@@ -126,7 +126,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expected = new List<DirectionRange<double>> {expectedRange};
 
             return new TestCaseData(range1, range2, expected)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case03)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case03)}");
         }
 
         private static TestCaseData Case04()
@@ -143,7 +143,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expected = new List<DirectionRange<double>> ();
 
             return new TestCaseData(range1, range2, expected)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case04)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case04)}");
         }
 
         private static TestCaseData Case05()
@@ -172,7 +172,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expected = new List<DirectionRange<double>> {expectedRange1, expectedRange2};
 
             return new TestCaseData(range1, range2, expected)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case05)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case05)}");
         }
 
         private static TestCaseData Case06()
@@ -194,7 +194,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case06)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case06)}");
         }
 
         private static TestCaseData Case_SpInRBar_EpInRBar1()
@@ -214,7 +214,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = Enumerable.Empty<DirectionRange<double>>().ToList();
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInRBar_EpInRBar1)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_SpInRBar_EpInRBar1)}");
         }
 
         private static TestCaseData Case_SpInRBar_EpInRBar2()
@@ -236,7 +236,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInRBar_EpInRBar2)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_SpInRBar_EpInRBar2)}");
         }
 
         private static TestCaseData Case_SpInRBar_EpEqualsS()
@@ -256,7 +256,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = Enumerable.Empty<DirectionRange<double>>().ToList();
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInRBar_EpEqualsS)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_SpInRBar_EpEqualsS)}");
         }
 
         private static TestCaseData Case_SpInRBar_EpInR()
@@ -282,7 +282,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInRBar_EpInR)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_SpInRBar_EpInR)}");
         }
 
         private static TestCaseData Case_SpInRBar_EpEqualsE()
@@ -304,7 +304,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInRBar_EpEqualsE)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_SpInRBar_EpEqualsE)}");
         }
 
         private static TestCaseData Case_SpEqualsS_EpInR()
@@ -326,7 +326,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpEqualsS_EpInR)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_SpEqualsS_EpInR)}");
         }
 
         private static TestCaseData Case_SpEqualsS_EpEqualsE()
@@ -348,7 +348,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpEqualsS_EpEqualsE)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_SpEqualsS_EpEqualsE)}");
         }
 
         private static TestCaseData Case_SpEqualsS_EpInRBar()
@@ -370,7 +370,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpEqualsS_EpInRBar)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_SpEqualsS_EpInRBar)}");
         }
 
         private static TestCaseData Case_SpInR_EpInR()
@@ -393,7 +393,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInR_EpInR)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_SpInR_EpInR)}");
         }
 
         private static TestCaseData Case_SpInR_EpEqualsE()
@@ -415,7 +415,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInR_EpEqualsE)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_SpInR_EpEqualsE)}");
         }
 
         private static TestCaseData Case_SpInR_EpInRBar()
@@ -441,7 +441,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInR_EpInRBar)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_SpInR_EpInRBar)}");
         }
 
         private static TestCaseData Case_SpInR_EpEqualsS()
@@ -467,7 +467,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInR_EpEqualsS)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_SpInR_EpEqualsS)}");
         }
 
         private static TestCaseData Case_SpInR_EpInR2()
@@ -499,7 +499,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection1, expectedIntersection2 };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpInR_EpInR2)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_SpInR_EpInR2)}");
         }
 
         private static TestCaseData Case_SpEqualsE_EpInRBar()
@@ -519,7 +519,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>>();
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpEqualsE_EpInRBar)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_SpEqualsE_EpInRBar)}");
         }
 
         private static TestCaseData Case_SpEqualsE_EpEqualsS()
@@ -539,7 +539,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>>();
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpEqualsE_EpEqualsS)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_SpEqualsE_EpEqualsS)}");
         }
 
         private static TestCaseData Case_SpEqualsE_EpInR()
@@ -565,7 +565,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_SpEqualsE_EpInR)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_SpEqualsE_EpInR)}");
         }
 
         private static TestCaseData Case_RDegenerate_SpEqualsS_EpInR()
@@ -588,7 +588,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDegenerate_SpEqualsS_EpInR)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_RDegenerate_SpEqualsS_EpInR)}");
         }
 
         private static TestCaseData Case_RDegenerate_SpInR_EpInR1()
@@ -611,7 +611,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDegenerate_SpInR_EpInR1)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_RDegenerate_SpInR_EpInR1)}");
         }
 
         private static TestCaseData Case_RDegenerate_SpInR_EpEqualsS()
@@ -634,7 +634,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDegenerate_SpInR_EpEqualsS)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_RDegenerate_SpInR_EpEqualsS)}");
         }
 
         private static TestCaseData Case_RDegenerate_SpInR_EpInR2()
@@ -667,7 +667,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection1, expectedIntersection2 };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDegenerate_SpInR_EpInR2)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_RDegenerate_SpInR_EpInR2)}");
         }
 
         private static TestCaseData Case_RDegenerateRpDegenerate_SEqualsSp()
@@ -690,7 +690,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDegenerateRpDegenerate_SEqualsSp)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_RDegenerateRpDegenerate_SEqualsSp)}");
         }
 
         private static TestCaseData Case_RDegenerateRpDegenerate_SpInR()
@@ -722,7 +722,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
             var expectedIntersections = new List<DirectionRange<double>> { expectedIntersection1, expectedIntersection2 };
 
             return new TestCaseData(range1, range2, expectedIntersections)
-                .SetName($"{nameof(DirectionRangeTestCaseDataSource)} - {nameof(Case_RDegenerateRpDegenerate_SpInR)}");
+                .SetName($"{nameof(DirectionRangeExtensionsIntersectionTestCaseDataSource)} - {nameof(Case_RDegenerateRpDegenerate_SpInR)}");
         }
     }
 }

--- a/tests/Hilke.KineticConvolution.Tests/TestCaseDataSource/DirectionRangeExtensionsUnionTestCaseDataSource.cs
+++ b/tests/Hilke.KineticConvolution.Tests/TestCaseDataSource/DirectionRangeExtensionsUnionTestCaseDataSource.cs
@@ -1,0 +1,763 @@
+﻿using System.Collections.Generic;
+
+using Hilke.KineticConvolution.DoubleAlgebraicNumber;
+
+using NUnit.Framework;
+
+namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
+{
+    internal static class DirectionRangeExtensionsUnionTestCaseDataSource
+    {
+        private static readonly IAlgebraicNumberCalculator<double> _calculator =
+            new DoubleAlgebraicNumberCalculator(zeroTolerance: 1.0e-12);
+
+        private static readonly ConvolutionFactory<double> _factory =
+            new ConvolutionFactory<double>(_calculator);
+
+        public static IEnumerable<TestCaseData> TestCases()
+        {
+            yield return Case01();
+            yield return Case02();
+            yield return Case03();
+            yield return Case04();
+            yield return Case05();
+            yield return Case06();
+
+            // Enumerate all combinatorial cases where range R = (S, E), range Rp = (Sp, Ep),
+            // RBar = (E, S) is the complement of range R, R and Rp are counter clockwise,
+            // S is not equal to E, and Sp is not equal to Ep.
+            yield return Case_SpInRBar_EpInRBar1();
+            yield return Case_SpInRBar_EpInRBar2();
+            yield return Case_SpInRBar_EpEqualsS();
+            yield return Case_SpInRBar_EpInR();
+            yield return Case_SpInRBar_EpEqualsE();
+            yield return Case_SpEqualsS_EpInR();
+            yield return Case_SpEqualsS_EpEqualsE();
+            yield return Case_SpEqualsS_EpInRBar();
+            yield return Case_SpInR_EpInR();
+            yield return Case_SpInR_EpEqualsE();
+            yield return Case_SpInR_EpInRBar();
+            yield return Case_SpInR_EpEqualsS();
+            yield return Case_SpInR_EpInR2();
+            yield return Case_SpEqualsE_EpInRBar();
+            yield return Case_SpEqualsE_EpEqualsS();
+            yield return Case_SpEqualsE_EpInR();
+
+            // Enumerate all combinatorial cases where range R = (S, S) is degenerate
+            // and Rp = (Sp, Ep), R and Rp are counter clockwise and Sp is not equal to Ep.
+            yield return Case_RDegenerate_SpEqualsS_EpInR();
+            yield return Case_RDegenerate_SpInR_EpInR1();
+            yield return Case_RDegenerate_SpInR_EpEqualsS();
+            yield return Case_RDegenerate_SpInR_EpInR2();
+
+            // Enumerate all combinatorial cases where range R = (S, S) is degenerate
+            // and Rp = (Sp, Sp) is degenerate.
+            yield return Case_RDegenerateRpDegenerate_SEqualsSp();
+            yield return Case_RDegenerateRpDegenerate_SpInR();
+        }
+
+        public static IEnumerable<TestCaseData> TestCasesMultipleUnion()
+        {
+            yield return MultipleUnionCase01();
+            yield return MultipleUnionCase02();
+        }
+
+        public static IEnumerable<TestCaseData> TestCasesSortByStart()
+        {
+            yield return SortCase01();
+        }
+
+        private static TestCaseData MultipleUnionCase01()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 1.0, y: 0.0),
+                _factory.CreateDirection(x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 1.0, y: 1.0),
+                _factory.CreateDirection(x: -1.0, y: 1.0),
+                Orientation.CounterClockwise);
+            var range3 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: -1.0, y: 0.0),
+                _factory.CreateDirection(x: 0.0, y: -1.0),
+                Orientation.CounterClockwise);
+            var range4 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: -1.0, y: -1.0),
+                _factory.CreateDirection(x: 1.0, y: -1.0),
+                Orientation.CounterClockwise);
+            var range5 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 7.0, y: -3.0),
+                _factory.CreateDirection(x: -0.1, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var ranges = new List<DirectionRange<double>> { range1, range2, range3, range4, range5 };
+
+            var union1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: -1.0, y: 0.0),
+                _factory.CreateDirection(x: 1.0, y: -1.0),
+                Orientation.CounterClockwise);
+            var union2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 7.0, y: -3.0),
+                _factory.CreateDirection(x: -1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expected = new List<DirectionRange<double>> { union1, union2 };
+            return new TestCaseData(ranges, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(MultipleUnionCase01)}");
+        }
+
+        private static TestCaseData MultipleUnionCase02()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 1.0, y: 0.0),
+                _factory.CreateDirection(x: 1.0, y: 1.0),
+                Orientation.CounterClockwise);
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 0.0, y: 1.0),
+                _factory.CreateDirection(x: -1.0, y: 1.0),
+                Orientation.CounterClockwise);
+            var range3 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: -1.0, y: 0.0),
+                _factory.CreateDirection(x: 0.0, y: -1.0),
+                Orientation.CounterClockwise);
+            var range4 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: -1.0, y: -1.0),
+                _factory.CreateDirection(x: 1.0, y: -1.0),
+                Orientation.CounterClockwise);
+            var range5 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 7.0, y: -3.0),
+                _factory.CreateDirection(x: -0.1, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var ranges = new List<DirectionRange<double>> { range1, range2, range3, range4, range5 };
+
+            var union1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: -1.0, y: 0.0),
+                _factory.CreateDirection(x: 1.0, y: -1.0),
+                Orientation.CounterClockwise);
+            var union2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 7.0, y: -3.0),
+                _factory.CreateDirection(x: -1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expected = new List<DirectionRange<double>> { union1, union2 };
+            return new TestCaseData(ranges, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(MultipleUnionCase02)}");
+        }
+
+        private static TestCaseData SortCase01()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 1.0, y: 0.0),
+                _factory.CreateDirection(x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 1.0, y: 1.0),
+                _factory.CreateDirection(x: -1.0, y: 1.0),
+                Orientation.CounterClockwise);
+            var range3 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: -1.0, y: 0.0),
+                _factory.CreateDirection(x: 0.0, y: -1.0),
+                Orientation.CounterClockwise);
+            var range4 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: -1.0, y: -1.0),
+                _factory.CreateDirection(x: 1.0, y: -1.0),
+                Orientation.CounterClockwise);
+            var range5 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 7.0, y: -3.0),
+                _factory.CreateDirection(x: -0.1, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var unsortedRanges = new List<DirectionRange<double>> { range1, range4, range3, range5, range2 };
+
+            var expected = new List<DirectionRange<double>> { range1, range2, range3, range4, range5 };
+
+            return new TestCaseData(unsortedRanges, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(SortCase01)}");
+        }
+
+        private static TestCaseData Case01()
+        {
+            var start1 = _factory.CreateDirection(1.0, 0.0);
+            var end1 = _factory.CreateDirection(0.0, 1.0);
+
+            var start2 = _factory.CreateDirection(0.5,  0.5);
+            var end2 = _factory.CreateDirection(0.0, -1.0);
+
+            var range1 = _factory.CreateDirectionRange( start1, end1, Orientation.CounterClockwise);
+            var range2 = _factory.CreateDirectionRange( start2, end2, Orientation.Clockwise);
+
+            var expectedRange = _factory.CreateDirectionRange(
+                _factory.CreateDirection(0.0, -1.0),
+                _factory.CreateDirection(0.0, 1.0),
+                Orientation.CounterClockwise);
+
+            var expected = new List<DirectionRange<double>> { expectedRange };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case01)}");
+        }
+
+        private static TestCaseData Case02()
+        {
+            var start1 = _factory.CreateDirection(1.0, 0.0);
+            var end1 = _factory.CreateDirection(0.0, 1.0);
+
+            var start2 = _factory.CreateDirection(0.5, 0.5);
+            var end2 = _factory.CreateDirection( 0.7, 0.3);
+
+            var range1 = _factory.CreateDirectionRange(start1, end1, Orientation.CounterClockwise);
+            var range2 = _factory.CreateDirectionRange(start2, end2, Orientation.CounterClockwise);
+
+            var expectedRange = _factory.CreateDirectionRange(
+                _factory.CreateDirection(1.0, 0.0),
+                _factory.CreateDirection(1.0, 0.0),
+                Orientation.CounterClockwise);
+
+            var expected = new List<DirectionRange<double>> { expectedRange, };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case02)}");
+        }
+
+        private static TestCaseData Case03()
+        {
+            var start1 = _factory.CreateDirection( x: 1.0, y: 0.0);
+            var end1 = _factory.CreateDirection( x: 0.0, y: 1.0);
+
+            var start2 = _factory.CreateDirection( x: 1.0, y: 0.0);
+            var end2 = _factory.CreateDirection(x: 0.0, y: 1.0);
+
+            var range1 = _factory.CreateDirectionRange(start1, end1, Orientation.CounterClockwise);
+            var range2 = _factory.CreateDirectionRange(start2, end2, Orientation.CounterClockwise);
+
+            var expectedRange = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expected = new List<DirectionRange<double>> { expectedRange };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case03)}");
+        }
+
+        private static TestCaseData Case04()
+        {
+            var start1 = _factory.CreateDirection( x: 1.0, y: 0.0);
+            var end1 = _factory.CreateDirection( x: 0.0, y: 1.0);
+
+            var start2 = _factory.CreateDirection( x: 0.0, y: 1.0);
+            var end2 = _factory.CreateDirection( x: 1.0, y: 0.0);
+
+            var range1 = _factory.CreateDirectionRange(start1, end1, Orientation.CounterClockwise);
+            var range2 = _factory.CreateDirectionRange(start2, end2, Orientation.CounterClockwise);
+
+            var expectedRange = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 1.0, y: 0.0),
+                _factory.CreateDirection(x: 1.0, y: 0.0),
+                Orientation.CounterClockwise);
+
+            var expected = new List<DirectionRange<double>> { expectedRange };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case04)}");
+        }
+
+        private static TestCaseData Case05()
+        {
+            var start1 = _factory.CreateDirection( x: 0.0, y: 1.0);
+            var end1 = _factory.CreateDirection( x: 0.0, y: 1.0);
+
+            var start2 = _factory.CreateDirection( x: 1.0, y: 0.0);
+            var end2 = _factory.CreateDirection( x: -1.0, y: 0.0);
+
+            var range1 = _factory.CreateDirectionRange( start1, end1, Orientation.CounterClockwise);
+            var range2 = _factory.CreateDirectionRange( start2, end2, Orientation.CounterClockwise);
+
+            var expectedRange = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 0.0, y: 1.0),
+                _factory.CreateDirection(x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expected = new List<DirectionRange<double>> { expectedRange };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case05)}");
+        }
+
+        private static TestCaseData Case06()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 0.0, y: -3.0),
+                _factory.CreateDirection( x: 0.0, y: -3.0),
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 0.0, y: -3.0),
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                Orientation.CounterClockwise);
+
+            var expectedUnion = range1;
+
+            var expected = new List<DirectionRange<double>> { expectedUnion };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case06)}");
+        }
+
+        private static TestCaseData Case_SpInRBar_EpInRBar1()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: -1.0, y: 1.0),
+                _factory.CreateDirection( x: -1.0, y: 0.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersections = new List<DirectionRange<double>> { range1, range2 };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_SpInRBar_EpInRBar1)}");
+        }
+
+        private static TestCaseData Case_SpInRBar_EpInRBar2()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: -1.0, y: 1.0),
+                _factory.CreateDirection( x: -0.5, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expected = new List<DirectionRange<double>> { range2 };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_SpInRBar_EpInRBar2)}");
+        }
+
+        private static TestCaseData Case_SpInRBar_EpEqualsS()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: -1.0, y: -1.0),
+                _factory.CreateDirection(x: 1.0, y: 0.0),
+                Orientation.CounterClockwise);
+
+            var expected = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: -1.0, y: -1.0),
+                _factory.CreateDirection(x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersections = new List<DirectionRange<double>> { expected };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_SpInRBar_EpEqualsS)}");
+        }
+
+        private static TestCaseData Case_SpInRBar_EpInR()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 1.0, y: 0.0),
+                _factory.CreateDirection(x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: -1.0, y: -1.0),
+                _factory.CreateDirection(x: 1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expected = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: -1.0, y: -1.0),
+                _factory.CreateDirection(x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersections = new List<DirectionRange<double>> { expected };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_SpInRBar_EpInR)}");
+        }
+
+        private static TestCaseData Case_SpInRBar_EpEqualsE()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 1.0, y: 0.0),
+                _factory.CreateDirection(x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: -1.0, y: -1.0),
+                _factory.CreateDirection(x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expected = new List<DirectionRange<double>> { range2 };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_SpInRBar_EpEqualsE)}");
+        }
+
+        private static TestCaseData Case_SpEqualsS_EpInR()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 1.0, y: 0.0),
+                _factory.CreateDirection(x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 1.0, y: 0.0),
+                _factory.CreateDirection(x: 1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expected = new List<DirectionRange<double>> { range1 };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_SpEqualsS_EpInR)}");
+        }
+
+        private static TestCaseData Case_SpEqualsS_EpEqualsE()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 1.0, y: 0.0),
+                _factory.CreateDirection(x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expected = new List<DirectionRange<double>> { range1 };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_SpEqualsS_EpEqualsE)}");
+        }
+
+        private static TestCaseData Case_SpEqualsS_EpInRBar()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                _factory.CreateDirection(x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 1.0, y: 0.0),
+                _factory.CreateDirection(x: -1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expected = new List<DirectionRange<double>> { range2 };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_SpEqualsS_EpInRBar)}");
+        }
+
+        private static TestCaseData Case_SpInR_EpInR()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 1.0, y: 0.0),
+                _factory.CreateDirection(x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 1.0, y: 1.0),
+                _factory.CreateDirection(x: 0.5, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expected = new List<DirectionRange<double>> { range1 };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_SpInR_EpInR)}");
+        }
+
+        private static TestCaseData Case_SpInR_EpEqualsE()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 1.0),
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expected = new List<DirectionRange<double>> { range1 };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_SpInR_EpEqualsE)}");
+        }
+
+        private static TestCaseData Case_SpInR_EpInRBar()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 1.0),
+                _factory.CreateDirection( x: -1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expected = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                _factory.CreateDirection( x: -1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersections = new List<DirectionRange<double>> { expected };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_SpInR_EpInRBar)}");
+        }
+
+        private static TestCaseData Case_SpInR_EpEqualsS()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 1.0),
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expected = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedIntersections = new List<DirectionRange<double>> { expected };
+
+            return new TestCaseData(range1, range2, expectedIntersections)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_SpInR_EpEqualsS)}");
+        }
+
+        private static TestCaseData Case_SpInR_EpInR2()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 1.0),
+                _factory.CreateDirection( x: 1.0, y: 0.5),
+                Orientation.CounterClockwise);
+
+            var expectedUnion = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                Orientation.CounterClockwise);
+
+            var expected = new List<DirectionRange<double>> { expectedUnion };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_SpInR_EpInR2)}");
+        }
+
+        // interesting for union
+        private static TestCaseData Case_SpEqualsE_EpInRBar()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                _factory.CreateDirection( x: -1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedUnion = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 1.0, y: 0.0),
+                _factory.CreateDirection(x: -1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expected = new List<DirectionRange<double>> { expectedUnion };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_SpEqualsE_EpInRBar)}");
+        }
+
+        // interesting for union
+        private static TestCaseData Case_SpEqualsE_EpEqualsS()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                Orientation.CounterClockwise);
+
+            var expectedUnion = _factory.CreateDirectionRange(
+                _factory.CreateDirection(x: 1.0, y: 0.0),
+                _factory.CreateDirection(x: 1.0, y: 0.0),
+                Orientation.CounterClockwise);
+
+            var expected = new List<DirectionRange<double>> { expectedUnion };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_SpEqualsE_EpEqualsS)}");
+        }
+
+        private static TestCaseData Case_SpEqualsE_EpInR()
+        {
+            var range1 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                _factory.CreateDirection( x: 1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedUnion = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                _factory.CreateDirection( x: 1.0, y: 0.0),
+                Orientation.CounterClockwise);
+
+            var expectedUnions = new List<DirectionRange<double>> { expectedUnion };
+
+            return new TestCaseData(range1, range2, expectedUnions)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_SpEqualsE_EpInR)}");
+        }
+
+        private static TestCaseData Case_RDegenerate_SpEqualsS_EpInR()
+        {
+            var S = _factory.CreateDirection( x: 1.0, y: 0.0);
+
+            var range1 = _factory.CreateDirectionRange(
+                S, S,
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                S,
+                _factory.CreateDirection( x: 1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedUnion = range1;
+
+            var expected = new List<DirectionRange<double>> { expectedUnion };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_RDegenerate_SpEqualsS_EpInR)}");
+        }
+
+        private static TestCaseData Case_RDegenerate_SpInR_EpInR1()
+        {
+            var S = _factory.CreateDirection( x: 1.0, y: 0.0);
+
+            var range1 = _factory.CreateDirectionRange(
+                S, S,
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 1.0),
+                _factory.CreateDirection( x: -1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expectedUnion = range1;
+
+            var expected = new List<DirectionRange<double>> { expectedUnion };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_RDegenerate_SpInR_EpInR1)}");
+        }
+
+        private static TestCaseData Case_RDegenerate_SpInR_EpEqualsS()
+        {
+            var S = _factory.CreateDirection( x: 1.0, y: 0.0);
+
+            var range1 = _factory.CreateDirectionRange(
+                S, S,
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 1.0, y: 1.0),
+                S,
+                Orientation.CounterClockwise);
+
+            var expectedUnion = range1;
+
+            var expected = new List<DirectionRange<double>> { expectedUnion };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_RDegenerate_SpInR_EpEqualsS)}");
+        }
+
+        private static TestCaseData Case_RDegenerate_SpInR_EpInR2()
+        {
+            var S = _factory.CreateDirection( x: 1.0, y: 0.0);
+
+            var range1 = _factory.CreateDirectionRange(
+                S, S,
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                _factory.CreateDirection( x: 0.0, y: 1.0),
+                _factory.CreateDirection( x: 1.0, y: 1.0),
+                Orientation.CounterClockwise);
+
+            var expected = new List<DirectionRange<double>> { range1 };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_RDegenerate_SpInR_EpInR2)}");
+        }
+
+        private static TestCaseData Case_RDegenerateRpDegenerate_SEqualsSp()
+        {
+            var S = _factory.CreateDirection( x: 1.0, y: 0.0);
+
+            var range1 = _factory.CreateDirectionRange(
+                S, S,
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                S,
+                S,
+                Orientation.CounterClockwise);
+
+            var expectedUnion = range2;
+
+            var expected = new List<DirectionRange<double>> { expectedUnion };
+
+            return new TestCaseData(range1, range2, expected)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_RDegenerateRpDegenerate_SEqualsSp)}");
+        }
+
+        private static TestCaseData Case_RDegenerateRpDegenerate_SpInR()
+        {
+            var S = _factory.CreateDirection( x: 1.0, y: 0.0);
+
+            var Sp = _factory.CreateDirection( x: 0.0, y: 1.0);
+
+            var range1 = _factory.CreateDirectionRange(
+                S, S,
+                Orientation.CounterClockwise);
+
+            var range2 = _factory.CreateDirectionRange(
+                Sp, Sp,
+                Orientation.CounterClockwise);
+
+            var expectedUnions = new List<DirectionRange<double>> { range1 };
+
+            return new TestCaseData(range1, range2, expectedUnions)
+                .SetName($"{nameof(DirectionRangeExtensionsUnionTestCaseDataSource)} - {nameof(Case_RDegenerateRpDegenerate_SpInR)}");
+        }
+    }
+}


### PR DESCRIPTION
Move the code that FeD wrote that is related to the objects defined in KineticConvolution.

This is essentially the implementation of the union of a pair of `DirectionRange`, union of a collection of such ranges, and sorting methods over collections of `DirectionRange`.