### PR TITLE
Fix the union of 0 or 1 direction range(s)

### DIFF
--- a/src/Hilke.KineticConvolution/Extensions/DirectionRangesExtensions.cs
+++ b/src/Hilke.KineticConvolution/Extensions/DirectionRangesExtensions.cs
@@ -22,7 +22,7 @@ namespace Hilke.KineticConvolution.Extensions
 
             var disjointUnions = new Queue<DirectionRange<double>>();
             var stagingUnion = orderedRanges[0];
-            foreach (var currentRange in orderedRanges)
+            foreach (var currentRange in orderedRanges.Skip(1))
             {
                 var unionWithStaging = stagingUnion.Union(currentRange).ToList();
                 if(unionWithStaging.Count == 2)
@@ -36,7 +36,7 @@ namespace Hilke.KineticConvolution.Extensions
                 }
             }
 
-            if (disjointUnions.Peek().Start.BelongsTo(stagingUnion))
+            if (disjointUnions.Count > 0 && disjointUnions.Peek().Start.BelongsTo(stagingUnion))
             {
                 // The last stagingUnion still intersect some ranges
                 // at the front of the queue.

--- a/tests/Hilke.KineticConvolution.Tests/DirectionRangeExtensionsTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/DirectionRangeExtensionsTests.cs
@@ -8,6 +8,7 @@ using Hilke.KineticConvolution.Extensions;
 using Hilke.KineticConvolution.Tests.TestCaseDataSource;
 
 using NUnit.Framework;
+using System;
 
 namespace Hilke.KineticConvolution.Tests
 {
@@ -142,6 +143,44 @@ namespace Hilke.KineticConvolution.Tests
             // Assert
             actual.Should().HaveCount(expected.Count);
             actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Test]
+        public void When_calling_Union_with_null_source_Then_ArgumentNullException_should_be_thrown()
+        {
+            // Act
+            Action action = () => ((IEnumerable<DirectionRange<double>>)null).Union();
+
+            // Assert
+            action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("ranges");
+        }
+
+        [Test]
+        public void When_calling_Union_with_empty_source_Then_empty_collection_should_be_returned()
+        {
+            // Act
+            var union = Enumerable.Empty<DirectionRange<double>>().Union();
+
+            // Assert
+            union.Should().BeEmpty();
+        }
+
+        [Test]
+        public void When_calling_Union_with_a_single_element_then_it_should_be_returned()
+        {
+            // Arrange
+            var factory = new ConvolutionFactory();
+
+            var d1 = factory.CreateDirection(1.0, 0.0);
+            var d2 = factory.CreateDirection(0.0, 1.0);
+            var range = factory.CreateDirectionRange(d1, d2, Orientation.CounterClockwise);
+            var ranges = new[] { range };
+
+            // Act
+            var union = ranges.Union();
+
+            // Assert
+            union.Single().Should().Be(range);
         }
     }
 }


### PR DESCRIPTION
The union of exactly 0 or 1 direction ranges (which should be the identity, in practice) was not handled properly, and led to dequeuing an element from an empty queue.