### PR TITLE
Setup gitversion in the workflow

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,4 +1,4 @@
-name: .NET Core
+name: Build, test and deploy .NET Core solution
 on:
   push:
   pull_request:
@@ -12,13 +12,16 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   # Project name to pack and publish
   PROJECT_NAME: Hilke.KineticConvolution
-  # GitHub Packages Feed settings
+
+# GitHub Packages Feed settings
   GITHUB_FEED: https://nuget.pkg.github.com/hilke-kineticconvolution/
   GITHUB_USER: thomashilke
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # Official NuGet Feed settings
+
+# Official NuGet Feed settings
   NUGET_FEED: https://api.nuget.org/v3/index.json
   NUGET_KEY: ${{ secrets.NUGET_KEY }}
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -26,21 +29,41 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 5.0.101
+
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.9.7
+        with:
+          versionSpec: '5.x'
+
       - name: Restore
         run: dotnet restore
+
       - name: Build
         run: dotnet build -c Release --no-restore
+
       - name: Test
         run: dotnet test -c Release --no-build
+
+      - name: Determine Version
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.9.7
+
+      - name: Display SemVer
+        run: |
+          echo "SemVer: ${{ steps.gitversion.outputs.semVer }}"
+
       - name: Pack
         if: matrix.os == 'ubuntu-latest'
-        run: dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$GITHUB_RUN_ID src/$PROJECT_NAME/$PROJECT_NAME.*proj
+        run: dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=${{ steps.gitversion.outputs.semVer }} src/$PROJECT_NAME/$PROJECT_NAME.*proj
       - name: Upload Artifact
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v2
@@ -67,7 +90,10 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -57,10 +57,6 @@ jobs:
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.9.7
 
-      - name: Display SemVer
-        run: |
-          echo "SemVer: ${{ steps.gitversion.outputs.semVer }}"
-
       - name: Pack
         if: matrix.os == 'ubuntu-latest'
         run: dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=${{ steps.gitversion.outputs.semVer }} src/$PROJECT_NAME/$PROJECT_NAME.*proj
@@ -94,18 +90,21 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 5.0.101
+
+      - name: Determine Version
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.9.7
+
+
       - name: Create Release NuGet package
         run: |
-          arrTag=(${GITHUB_REF//\// })
-          VERSION="${arrTag[2]}"
-          echo Version: $VERSION
-          VERSION="${VERSION//v}"
-          echo Clean Version: $VERSION
-          dotnet pack -v normal -c Release --include-symbols --include-source -p:PackageVersion=$VERSION -o nupkg src/$PROJECT_NAME/$PROJECT_NAME.*proj
+          dotnet pack -v normal -c Release --include-symbols --include-source -p:PackageVersion=${{ steps.gitversion.outputs.semVer }} -o nupkg src/$PROJECT_NAME/$PROJECT_NAME.*proj
+
       - name: Push to GitHub Feed
         run: |
           for f in ./nupkg/*.nupkg

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,1 @@
+mode: Mainline

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,1 +1,2 @@
 mode: Mainline
+tag-prefix: ''

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,2 +1,5 @@
-mode: Mainline
+mode: ContinuousDeployment
 tag-prefix: ''
+branches:
+  master:
+    tag: beta


### PR DESCRIPTION
The current pipeline use the `$GITHUB_RUN_ID` environment variable as the major version for the prerelease package version that are pushed on the Github nuget feed. 

However, the value of `$GITHUB_RUN_ID` recently reached `Int32.MaxValue`, which is the highest possible version for a nuget package. 

This PR setup GitVersion to calculate proper package version.