### PR TITLE
Fix sample project with the code from the readmme

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -35,9 +35,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 5.0.101
+          dotnet-version: 6.0.x
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.7

--- a/KineticConvolution.sln
+++ b/KineticConvolution.sln
@@ -1,15 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30804.86
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32414.318
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4B550C17-7848-4B2D-B690-EBE3ACEAA3DE}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KineticConvolution", "src\Hilke.KineticConvolution\Hilke.KineticConvolution.csproj", "{12DAD913-2412-4018-9C0D-53206ED68DFB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hilke.KineticConvolution", "src\Hilke.KineticConvolution\Hilke.KineticConvolution.csproj", "{12DAD913-2412-4018-9C0D-53206ED68DFB}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{5B9941FD-71C9-4092-98D6-9648B4C37F0D}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KineticConvolution.Tests", "tests\Hilke.KineticConvolution.Tests\Hilke.KineticConvolution.Tests.csproj", "{2C93819A-383D-48EE-AB60-7ED0428E8D55}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hilke.KineticConvolution.Tests", "tests\Hilke.KineticConvolution.Tests\Hilke.KineticConvolution.Tests.csproj", "{2C93819A-383D-48EE-AB60-7ED0428E8D55}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B52D0A5C-2AD2-4A0C-8E65-3F91A3231602}"
 	ProjectSection(SolutionItems) = preProject
@@ -24,6 +24,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{7527BC77
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\build-deploy.yml = .github\workflows\build-deploy.yml
 	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{2EDEEBF0-0F38-41A1-BF6C-F03E79D0EEF1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hilke.KineticConvolution.ReadMeExamples", "samples\Hilke.KineticConvolution.ReadMeExamples\Hilke.KineticConvolution.ReadMeExamples.csproj", "{E522759B-6A0B-4042-94EB-7CE3DA367371}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -59,6 +63,18 @@ Global
 		{2C93819A-383D-48EE-AB60-7ED0428E8D55}.Release|x64.Build.0 = Release|Any CPU
 		{2C93819A-383D-48EE-AB60-7ED0428E8D55}.Release|x86.ActiveCfg = Release|Any CPU
 		{2C93819A-383D-48EE-AB60-7ED0428E8D55}.Release|x86.Build.0 = Release|Any CPU
+		{E522759B-6A0B-4042-94EB-7CE3DA367371}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E522759B-6A0B-4042-94EB-7CE3DA367371}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E522759B-6A0B-4042-94EB-7CE3DA367371}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E522759B-6A0B-4042-94EB-7CE3DA367371}.Debug|x64.Build.0 = Debug|Any CPU
+		{E522759B-6A0B-4042-94EB-7CE3DA367371}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E522759B-6A0B-4042-94EB-7CE3DA367371}.Debug|x86.Build.0 = Debug|Any CPU
+		{E522759B-6A0B-4042-94EB-7CE3DA367371}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E522759B-6A0B-4042-94EB-7CE3DA367371}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E522759B-6A0B-4042-94EB-7CE3DA367371}.Release|x64.ActiveCfg = Release|Any CPU
+		{E522759B-6A0B-4042-94EB-7CE3DA367371}.Release|x64.Build.0 = Release|Any CPU
+		{E522759B-6A0B-4042-94EB-7CE3DA367371}.Release|x86.ActiveCfg = Release|Any CPU
+		{E522759B-6A0B-4042-94EB-7CE3DA367371}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -66,6 +82,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{12DAD913-2412-4018-9C0D-53206ED68DFB} = {4B550C17-7848-4B2D-B690-EBE3ACEAA3DE}
 		{2C93819A-383D-48EE-AB60-7ED0428E8D55} = {5B9941FD-71C9-4092-98D6-9648B4C37F0D}
+		{E522759B-6A0B-4042-94EB-7CE3DA367371} = {2EDEEBF0-0F38-41A1-BF6C-F03E79D0EEF1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4766386D-4073-4773-B385-3C5C665F4A7A}

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ convolution of `parent1` from `shape1` and `parent2` from `shape2`.
 Instance of `Shape<T>`, as well as every other objects must be
 instantiated through a factory instance of
 `IConvolutionFactory<TAlgebraicNumber>`. More about the reasons for
-this design is given in section Factory and algebraic numbers
+this design is given in section [Factory and algebraic numbers](#factory-and-algebraic-numbers)
 below.
 
 # Factory and algebraic numbers

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ be used to create geometric entities:
 ```
 
 Given `shape1` and `shape2` of type `Shape<T>` which represent two
-polygonal tracings, the kinetic convolution of those two tracings is
-obtained by calling
+polygonal tracings and `factory` of type
+`IConvolutionFactory<double>`, the kinetic convolution of those two
+tracings is obtained by calling
 ```C#
-    var factory = new ConvolutionFactory();
     var convolution = factory.ConvolveShapes(shape1, shape2);
 ```
 Note that if `shape1` and `shape2` represent the boundary of two
@@ -72,9 +72,7 @@ Instance of `Shape<T>`, as well as every other objects must be
 instantiated through a factory instance of
 `IConvolutionFactory<TAlgebraicNumber>`. More about the reasons for
 this design is given in section Factory and algebraic numbers
-below. As a convenience, an implementation of
-`IConvolutionFactory<double>` is provided by
-`DoubleAlgebraicNumber.ConvolutionFactory` that can be used as-is.
+below.
 
 # Factory and algebraic numbers
 A fundamental initial requirement of this implementation was the
@@ -120,24 +118,21 @@ the factory's methods `CreatePoint`, `CreateSegment`, etc.
 The following example demonstrates the library usage to compute the
 convolution of a unit disk with a straight line. The two shapes being
 convex, the result is the boundary of the Minkowski sum of the two
-shapes.
+shapes. The following code can be found ready to run in the project
+`samples/Hilke.KineticConvolution.ReadMeExamples/`.
 
 ```C#
-using Fractions;
-
 using Hilke.KineticConvolution;
 using Hilke.KineticConvolution.DoubleAlgebraicNumber;
 
-using System;
-using System.Collections.Generic;
-
-namespace Rollomatic.Conv
+namespace Rollomatic.KinematicConvolution.ReadMeExamples
 {
-    class Program
+    class WorkingExample
     {
-        static void Main(string[] args)
+        static void Run()
         {
-            var factory = new ConvolutionFactory();
+            var calculator = new DoubleAlgebraicNumberCalculator();
+            var factory = new ConvolutionFactory<double>(calculator);
 
             var disk = CreateDiskShape(factory);
 
@@ -164,7 +159,7 @@ namespace Rollomatic.Conv
             }
         }
 
-        static Shape<double> CreateDiskShape(ConvolutionFactory factory)
+        static Shape<double> CreateDiskShape(ConvolutionFactory<double> factory)
         {
             var eastDirection = factory.CreateDirection(1.0, 0.0);
 
@@ -177,7 +172,7 @@ namespace Rollomatic.Conv
             return factory.CreateShape(new[] { diskArc });
         }
 
-        static Shape<double> CreatePathShape(ConvolutionFactory factory)
+        static Shape<double> CreatePathShape(ConvolutionFactory<double> factory)
         {
             var pathSegment = factory.CreateSegment(
                 startX: 0.0, startY: 0.0,
@@ -192,8 +187,8 @@ namespace Rollomatic.Conv
             var smoothingArc1 = factory.CreateArc(
                 pathSegment.Start,
                 factory.CreateDirectionRange(
-                    pathReverseSegment.Direction().NormalDirection().Opposite(),
-                    pathSegment.Direction().NormalDirection().Opposite(),
+                    pathReverseSegment.EndTangentDirection.NormalDirection().Opposite(),
+                    pathSegment.StartTangentDirection.NormalDirection().Opposite(),
                     Orientation.CounterClockwise),
                 0.0,
                 1);
@@ -201,8 +196,8 @@ namespace Rollomatic.Conv
             var smoothingArc2 = factory.CreateArc(
                 pathReverseSegment.Start,
                 factory.CreateDirectionRange(
-                    pathSegment.Direction().NormalDirection().Opposite(),
-                    pathReverseSegment.Direction().NormalDirection().Opposite(),
+                    pathSegment.StartTangentDirection.NormalDirection().Opposite(),
+                    pathReverseSegment.EndTangentDirection.NormalDirection().Opposite(),
                     Orientation.CounterClockwise),
                 0.0,
                 1);

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ be used to create geometric entities:
 ```
 
 Given `shape1` and `shape2` of type `Shape<T>` which represent two
-polygonal tracings and `factory` of type
+tracings and `factory` of type
 `IConvolutionFactory<double>`, the kinetic convolution of those two
 tracings is obtained by calling
 ```C#

--- a/samples/Hilke.KineticConvolution.ReadMeExamples/Hilke.KineticConvolution.ReadMeExamples.csproj
+++ b/samples/Hilke.KineticConvolution.ReadMeExamples/Hilke.KineticConvolution.ReadMeExamples.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hilke.KineticConvolution\Hilke.KineticConvolution.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Hilke.KineticConvolution.ReadMeExamples/Snippets.cs
+++ b/samples/Hilke.KineticConvolution.ReadMeExamples/Snippets.cs
@@ -1,4 +1,6 @@
-﻿using Fractions;
+﻿#nullable disable
+
+using Fractions;
 
 using Hilke.KineticConvolution;
 using Hilke.KineticConvolution.DoubleAlgebraicNumber;

--- a/samples/Hilke.KineticConvolution.ReadMeExamples/Snippets.cs
+++ b/samples/Hilke.KineticConvolution.ReadMeExamples/Snippets.cs
@@ -1,0 +1,24 @@
+﻿using Fractions;
+
+using Hilke.KineticConvolution;
+using Hilke.KineticConvolution.DoubleAlgebraicNumber;
+
+var calculator = new DoubleAlgebraicNumberCalculator();
+var factory = new ConvolutionFactory<double>(calculator);
+
+var segment = factory.CreateSegment(
+    startX: 0.0, startY: 0.0,
+    endX: 1.0, endY: 2.0,
+    weight: new Fraction(2, 3));
+
+Shape<double> shape1 = null;
+Shape<double> shape2 = null;
+
+var convolution = factory.ConvolveShapes(shape1, shape2);
+
+foreach (var convolvedTracing in convolution.ConvolvedTracings)
+{
+    var parent1 = convolvedTracing.Parent1;
+    var parent2 = convolvedTracing.Parent2;
+    var tracing = convolvedTracing.Convolution;
+}

--- a/samples/Hilke.KineticConvolution.ReadMeExamples/WorkingExample.cs
+++ b/samples/Hilke.KineticConvolution.ReadMeExamples/WorkingExample.cs
@@ -1,0 +1,86 @@
+﻿using Hilke.KineticConvolution;
+using Hilke.KineticConvolution.DoubleAlgebraicNumber;
+
+namespace Rollomatic.KinematicConvolution.ReadMeExamples
+{
+    public static class WorkingExample
+    {
+        public static void Run()
+        {
+            var calculator = new DoubleAlgebraicNumberCalculator();
+            var factory = new ConvolutionFactory<double>(calculator);
+
+            var disk = CreateDiskShape(factory);
+
+            var pathShape = CreatePathShape(factory);
+
+            var minkowskiSum = factory.ConvolveShapes(disk, pathShape);
+
+            foreach (var convolvedTracing in minkowskiSum.ConvolvedTracings)
+            {
+                switch (convolvedTracing.Convolution)
+                {
+                    case Arc<double> arc:
+                        Console.WriteLine(
+      $"Boundary arc: center ({arc.Center.X}, {arc.Center.Y}), radius {arc.Radius}, " +
+      $"start ({arc.Start.X}, {arc.Start.Y}), end ({arc.End.X}, {arc.End.Y})");
+                        break;
+
+                    case Segment<double> segment:
+                        Console.WriteLine(
+$"Boundary segment: start ({segment.Start.X}, {segment.Start.Y}), end ({segment.End.X}, {segment.End.Y})");
+                        break;
+
+                    default:
+                        throw new InvalidOperationException("Unexpected tracing encountered.");
+                }
+            }
+        }
+
+        private static Shape<double> CreateDiskShape(ConvolutionFactory<double> factory)
+        {
+            var eastDirection = factory.CreateDirection(1.0, 0.0);
+
+            var diskArc = factory.CreateArc(
+                center: factory.CreatePoint(0.0, 0.0),
+                directions: factory.CreateDirectionRange(eastDirection, eastDirection, Orientation.CounterClockwise),
+                radius: 1.0,
+                weight: 1);
+
+            return factory.CreateShape(new[] { diskArc });
+        }
+
+        private static Shape<double> CreatePathShape(ConvolutionFactory<double> factory)
+        {
+            var pathSegment = factory.CreateSegment(
+                startX: 0.0, startY: 0.0,
+                endX: 1.0, endY: 2.0,
+                weight: 1);
+
+            var pathReverseSegment = factory.CreateSegment(
+                startX: 1.0, startY: 2.0,
+                endX: 0.0, endY: 0.0,
+                weight: 1);
+
+            var smoothingArc1 = factory.CreateArc(
+                pathSegment.Start,
+                factory.CreateDirectionRange(
+                    pathReverseSegment.EndTangentDirection.NormalDirection().Opposite(),
+                    pathSegment.StartTangentDirection.NormalDirection().Opposite(),
+                    Orientation.CounterClockwise),
+                0.0,
+                1);
+
+            var smoothingArc2 = factory.CreateArc(
+                pathReverseSegment.Start,
+                factory.CreateDirectionRange(
+                    pathSegment.StartTangentDirection.NormalDirection().Opposite(),
+                    pathReverseSegment.EndTangentDirection.NormalDirection().Opposite(),
+                    Orientation.CounterClockwise),
+                0.0,
+                1);
+
+            return factory.CreateShape(new Tracing<double>[] { smoothingArc1, pathSegment, smoothingArc2, pathReverseSegment });
+        }
+    }
+}

--- a/src/Hilke.KineticConvolution/DoubleAlgebraicNumber/ConvolutionFactory.cs
+++ b/src/Hilke.KineticConvolution/DoubleAlgebraicNumber/ConvolutionFactory.cs
@@ -1,9 +1,0 @@
-﻿namespace Hilke.KineticConvolution.DoubleAlgebraicNumber
-{
-    public sealed class ConvolutionFactory : ConvolutionFactory<double>
-    {
-        /// <inheritdoc />
-        public ConvolutionFactory()
-            : base(new DoubleAlgebraicNumberCalculator()) { }
-    }
-}

--- a/src/Hilke.KineticConvolution/DoubleAlgebraicNumber/DoubleConverter.cs
+++ b/src/Hilke.KineticConvolution/DoubleAlgebraicNumber/DoubleConverter.cs
@@ -13,7 +13,7 @@ namespace Hilke.KineticConvolution.DoubleAlgebraicNumber
             AlgebraicNumberFactory =
                 algebraicNumberConvolutionFactory
              ?? throw new ArgumentNullException(nameof(algebraicNumberConvolutionFactory));
-            DoubleFactory = new ConvolutionFactory();
+            DoubleFactory = new ConvolutionFactory<double>(new DoubleAlgebraicNumberCalculator());
 
             if (!Enum.IsDefined(typeof(InvalidConversionPolicy), policy))
             {

--- a/tests/Hilke.KineticConvolution.Tests/AlgebraicNumberCalculatorExtensionsTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/AlgebraicNumberCalculatorExtensionsTests.cs
@@ -16,7 +16,7 @@ namespace Hilke.KineticConvolution.Tests
         [SetUp]
         public void SetUp()
         {
-            var factory = new ConvolutionFactory();
+            var factory = new ConvolutionFactory<double>(new DoubleAlgebraicNumberCalculator());
             _calculator = factory.AlgebraicNumberCalculator;
         }
 

--- a/tests/Hilke.KineticConvolution.Tests/ConvolutionFactoryTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/ConvolutionFactoryTests.cs
@@ -625,7 +625,7 @@ namespace Hilke.KineticConvolution.Tests
         [Test]
         public void Working_Example_From_Readme_Should_Compile_And_Produce_Correct_Results()
         {
-            var factory = new ConvolutionFactory();
+            var factory = new ConvolutionFactory<double>(new DoubleAlgebraicNumberCalculator());
 
             var disk = CreateDiskShape(factory);
 
@@ -635,7 +635,7 @@ namespace Hilke.KineticConvolution.Tests
 
             minkowskiSum.ConvolvedTracings.Should().HaveCount(5);
 
-            static Shape<double> CreateDiskShape(ConvolutionFactory factory)
+            static Shape<double> CreateDiskShape(ConvolutionFactory<double> factory)
             {
                 var eastDirection = factory.CreateDirection(1.0, 0.0);
 
@@ -648,7 +648,7 @@ namespace Hilke.KineticConvolution.Tests
                 return factory.CreateShape(new[] { diskArc });
             }
 
-            static Shape<double> CreatePathShape(ConvolutionFactory factory)
+            static Shape<double> CreatePathShape(ConvolutionFactory<double> factory)
             {
                 var pathSegment = factory.CreateSegment(
                     startX: 0.0, startY: 0.0,

--- a/tests/Hilke.KineticConvolution.Tests/ConvolutionHelperTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/ConvolutionHelperTests.cs
@@ -17,7 +17,7 @@ namespace Hilke.KineticConvolution.Tests
             const double radius1 = 2.0;
             const double radius2 = 2.0;
 
-            var convolutionFactory = new ConvolutionFactory();
+            var convolutionFactory = new ConvolutionFactory<double>(new DoubleAlgebraicNumberCalculator());
 
             var arc1 = convolutionFactory.CreateArc(
                 centerX: 1.0,

--- a/tests/Hilke.KineticConvolution.Tests/DirectionExtensionsTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/DirectionExtensionsTests.cs
@@ -12,7 +12,7 @@ namespace Hilke.KineticConvolution.Tests
         [Test]
         public void When_Direction_Is_Given_Then_BelongsTo_Should_Return_Expected_Result()
         {
-            var factory = new ConvolutionFactory();
+            var factory = new ConvolutionFactory<double>(new DoubleAlgebraicNumberCalculator());
 
             var east = factory.CreateDirection(1.0, 0.0);
             var north = factory.CreateDirection(0.0, 1.0);
@@ -33,7 +33,7 @@ namespace Hilke.KineticConvolution.Tests
         [Test]
         public void When_Direction_Is_Close_To_Range_Boundary_Then_BelongsTo_Should_Return_Expected_Result()
         {
-            var factory = new ConvolutionFactory();
+            var factory = new ConvolutionFactory<double>(new DoubleAlgebraicNumberCalculator());
 
             var northEast = factory.CreateDirection(1.0, 1.0);
             var northWest = factory.CreateDirection(-1.0, 1.0);

--- a/tests/Hilke.KineticConvolution.Tests/DirectionHelpersTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/DirectionHelpersTests.cs
@@ -14,7 +14,7 @@ namespace Hilke.KineticConvolution.Tests
         [Test]
         public void Direction_Determinant_Should_Have_Expected_Sign()
         {
-            var factory = new ConvolutionFactory();
+            var factory = new ConvolutionFactory<double>(new DoubleAlgebraicNumberCalculator());
 
             var d1 = factory.CreateDirection(1.0, 1.0);
             var d2 = factory.CreateDirection(-1.0, 1.0);

--- a/tests/Hilke.KineticConvolution.Tests/DirectionRangeExtensionsTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/DirectionRangeExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace Hilke.KineticConvolution.Tests
         [Test]
         public void IsShortestRange_Should_Return_Expected_Result()
         {
-            var factory = new ConvolutionFactory();
+            var factory = new ConvolutionFactory<double>(new DoubleAlgebraicNumberCalculator());
 
             var d1 = factory.CreateDirection(1.0, 0.0);
             var d2 = factory.CreateDirection(0.0, 1.0);
@@ -37,7 +37,7 @@ namespace Hilke.KineticConvolution.Tests
         [Test]
         public void When_Direction_Range_Is_Exactly_A_Half_Plan_Then_The_Shortest_Range_Should_Be_Clockwise()
         {
-            var factory = new ConvolutionFactory();
+            var factory = new ConvolutionFactory<double>(new DoubleAlgebraicNumberCalculator());
 
             var d1 = factory.CreateDirection(1.0, 0.0);
             var d2 = factory.CreateDirection(-1.0, 0.0);
@@ -62,7 +62,7 @@ namespace Hilke.KineticConvolution.Tests
             Orientation orientation,
             IEnumerable<DirectionRange<double>> expectedRange)
         {
-            var factory = new ConvolutionFactory();
+            var factory = new ConvolutionFactory<double>(new DoubleAlgebraicNumberCalculator());
 
             var d1 = factory.CreateDirection(0.0, 1.0);
             var d2 = factory.CreateDirection(0.0, -1.0);
@@ -169,7 +169,7 @@ namespace Hilke.KineticConvolution.Tests
         public void When_calling_Union_with_a_single_element_then_it_should_be_returned()
         {
             // Arrange
-            var factory = new ConvolutionFactory();
+            var factory = new ConvolutionFactory<double>(new DoubleAlgebraicNumberCalculator());
 
             var d1 = factory.CreateDirection(1.0, 0.0);
             var d2 = factory.CreateDirection(0.0, 1.0);

--- a/tests/Hilke.KineticConvolution.Tests/DirectionTests.cs
+++ b/tests/Hilke.KineticConvolution.Tests/DirectionTests.cs
@@ -16,7 +16,7 @@ namespace Hilke.KineticConvolution.Tests
     [TestFixture]
     public class DirectionTests
     {
-        private static readonly ConvolutionFactory Factory = new();
+        private static readonly ConvolutionFactory<double> Factory = new(new DoubleAlgebraicNumberCalculator());
         private Direction<double> _subject;
 
         [OneTimeSetUp]

--- a/tests/Hilke.KineticConvolution.Tests/Hilke.KineticConvolution.Tests.csproj
+++ b/tests/Hilke.KineticConvolution.Tests/Hilke.KineticConvolution.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Hilke.KineticConvolution.Tests/TestCaseDataSource/DirectionRangeExtensionsTestCaseDataSource.cs
+++ b/tests/Hilke.KineticConvolution.Tests/TestCaseDataSource/DirectionRangeExtensionsTestCaseDataSource.cs
@@ -11,7 +11,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
     {
         public static IEnumerable<TestCaseData> TestCases()
         {
-            var factory = new ConvolutionFactory();
+            var factory = new ConvolutionFactory<double>(new DoubleAlgebraicNumberCalculator());
 
             yield return new TestCaseData(
                 Orientation.CounterClockwise, Enumerable.Empty<DirectionRange<double>>());

--- a/tests/Hilke.KineticConvolution.Tests/TestCaseDataSource/DirectionTestCaseDataSource.cs
+++ b/tests/Hilke.KineticConvolution.Tests/TestCaseDataSource/DirectionTestCaseDataSource.cs
@@ -8,7 +8,7 @@ namespace Hilke.KineticConvolution.Tests.TestCaseDataSource
 {
     public static class DirectionTestCaseDataSource
     {
-        private static readonly ConvolutionFactory Factory = new();
+        private static readonly ConvolutionFactory<double> Factory = new(new DoubleAlgebraicNumberCalculator());
 
         public static IEnumerable<TestCaseData> TestCases()
         {


### PR DESCRIPTION
The code samples in the readme.md where out of date with respect of the code in the repository.

In order to spot when the examples come out of date, the code is now also part of a project in the `samples` subdirectory. When the code there must be updated, it can simply be copied back into the readme.

Also, the shortcut `DoubleAlgebraicNumber/ConvolutionFactory.cs` was removed, because it's presence does more harm than good, and confuses everyone.